### PR TITLE
github: Cache virtualenv

### DIFF
--- a/.github/workflows/check_protos.yml
+++ b/.github/workflows/check_protos.yml
@@ -25,7 +25,6 @@ jobs:
           poetry-version: ${{ env.POETRY_VERSION }}
       - name: Cache virtualenv
         uses: actions/cache@v3
-        id: cache
         with:
           path: .github/check_protos/.venv
           key: check-protos-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('.github/check_protos/poetry.lock') }}


### PR DESCRIPTION
### What does this Pull Request accomplish?

Cache the `check_protos` virtualenv so it is only rebuilt when `poetry.lock` changes.

Also rename the install dependencies step.

### Why should this Pull Request be merged?

Avoid downloading packages from PyPI for every PR/CI build.

In the measurementlink-python repo, caching venvs had a significant performance benefit. For this project, it's more about being a good citizen (don't waste bandwidth) and eliminating a point of failure.

### What testing has been done?

PR build