### PR TITLE
Add .yml to trigger the CI in AzDO

### DIFF
--- a/.github/workflows/trigger_azdo_ci.yml
+++ b/.github/workflows/trigger_azdo_ci.yml
@@ -1,0 +1,24 @@
+name: Trigger AzDO CIs
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  trigger_azdo_ci:
+    name: Trigger Main CI
+    runs-on: windows-latest
+    steps:
+    - name: Trigger Main CI 
+      uses: Azure/pipelines@v1.2
+      if: ${{ github.repository == 'ni/ni-apis' && github.event.workflow_run.head_branch == 'main' }}
+      with:
+        azure-devops-project-url: 'https://dev.azure.com/ni/DevCentral'
+        azure-pipeline-name: 'ASW-ni-apis-ci'
+        azure-devops-token: ${{ secrets.AZDO_PIPELINE_TRIGGERS }}
+        azure-pipeline-variables: '{"BRANCH": "main", "EXPORT_NAME": "ni-apis", "PHASE": "d"}'


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds a workflow to run when a CI happens. This kicks off a new pipeline in Azure Dev Ops that will produce exports (eventually, for now it does not much of anything).

### Why should this Pull Request be merged?

Step toward having exports for each checkin to the repo that can be built into a nuget.

### What testing has been done?

None. Will test once submitted.
