### PR TITLE
Sync Pin Map and Session Management Service Proto: Multiplexer Data Changes

### DIFF
--- a/ni/measurementlink/pinmap/v1/pin_map_service.proto
+++ b/ni/measurementlink/pinmap/v1/pin_map_service.proto
@@ -209,7 +209,7 @@ message ResourceAccessInformation {
     string instrument_type_id = 3;
 
     // List of site and pin/relay mappings with the multiplexer info for each channel in the channel_list.
-    // Each item represents a channel-to-pin connection in this instrument resource. In the case of shared pins, it has a separate item for each connection.
+    // Each item represents a channel-to-pin connection for this instrument resource. In the case of shared pins, there is a separate item for each connection.
     repeated ChannelMapping channel_mappings = 4;
 }
 

--- a/ni/measurementlink/sessionmanagement/v1/session_management_service.proto
+++ b/ni/measurementlink/sessionmanagement/v1/session_management_service.proto
@@ -85,7 +85,7 @@ message SessionInformation{
     bool session_exists = 5;
 
     // List of site and pin/relay mappings with the multiplexer info for each channel in the channel_list.
-    // Each item represents a channel-to-pin connection in this instrument resource. In the case of shared pins, it has a separate item for each connection.
+    // Each item represents a channel-to-pin connection for this instrument resource. In the case of shared pins, there is a separate item for each connection.
     // This field is empty for any SessionInformation returned from ReserveAllRegisteredSessions.
     // This field is readonly.
     repeated ChannelMapping channel_mappings = 6;


### PR DESCRIPTION
### What does this Pull Request accomplish?
This PR updates the `pin_map_service.proto` and `session_management_service.proto` files to support multiplexer data.

### Why should this Pull Request be merged?
Ensures compatibility with the latest multiplexer data changes.

### What testing has been done?
None (`.proto` file changes only).