### PR TITLE
Update DiscoveryService with support for TestHub

### DIFF
--- a/ni/measurementlink/discovery/v1/discovery_service.proto
+++ b/ni/measurementlink/discovery/v1/discovery_service.proto
@@ -50,7 +50,7 @@ service DiscoveryService {
   // - FAILED_PRECONDITION: More than one service matching the resolve request was found
   rpc ResolveService(ResolveServiceRequest) returns (ServiceLocation);
 
-  // Enumerate all compute nodes that have registered themselves with TestHub.
+  // Enumerate all compute nodes that have registered themselves in the current session.
   // These compute nodes are targets available for execution of services.
   // A compute node can be used as an argument to the ResolveService method to
   // get the service location for a service running on that compute node.
@@ -156,19 +156,19 @@ message ResolveServiceRequest {
 }
 
 // Represents a location capable resolving and running a service.
-message ComputeNodeInfo {
+message ComputeNodeDescriptor {
   // The resolvable name of the compute node.
-  string node_name = 1;
+  string url = 1;
   // indicates whether the compute node is considered the local node.
   bool is_local = 2;
 }
 
-// Message sent to enumerate the compute nodes that have registered themselves with TestHub.
+// Message sent to enumerate the compute nodes that have registered themselves in the current session.
 message EnumerateComputeNodesRequest {
 }
 
 // Message returned from the EnumerateComputeNodes method.
 message EnumerateComputeNodesResponse {
-  // The list of compute nodes that have registered themselves with TestHub.
-  repeated ComputeNodeInfo compute_nodes = 1;
+  // The list of compute nodes that have registered themselves in the current session.
+  repeated ComputeNodeDescriptor compute_nodes = 1;
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR adds a single RPC to discovery service that will eventually enable remote execution of services.  This remote execution already works (but is disabled behind a feature toggle) in a branch off of ASW I will soon be opening as a PR. 

Specifically, the mew RPC is `EnumerateComputeNodes`. The behavior of the API is to return a list of "compute nodes" that have registered themselves with a TestHub instance.  A "compute node" is basically just another instance of Discovery Service running on another machine somewhere that has registered itself with TestHub.  Included in the list is the "local" compute node - corresponding to this local instance of DiscoveryService.  With this information, you can indicate to `ResolveService` that you want a particular service to be instanced and run on a particular "compute node".  

### Why should this Pull Request be merged?

This pull request is critical to the merging of our TestHub work into ASW.  We need to be able to maintain this API in order to demo and work on features created last yaer (including remote execution of services).

### What testing has been done?

In our branch off of ASW, this new RPC has been implemented server side and demo'd multiple times.
