### PR TITLE
Update Pin Map and Session Management Service Proto: Pin or Relay Groups support

### DIFF
--- a/ni/measurementlink/pinmap/v1/pin_map_service.proto
+++ b/ni/measurementlink/pinmap/v1/pin_map_service.proto
@@ -181,6 +181,9 @@ message QueryResourceAccessInformationRequest {
 message QueryResourceAccessInformationResponse {
     // List of ResourceAccessInformation objects with instrument resource names and channels.
     repeated ResourceAccessInformation resource_access_information = 1;
+
+    // Represents the mapping between pin or relay groups and their respective pin or relay names.
+    map<string, ResolvedPinsOrRelays> group_mappings = 2;
 }
 
 message ResourceAccessInformation {
@@ -232,4 +235,9 @@ message ChannelMapping {
 
     // User-defined identifier for the multiplexer type in the pin map editor.
     string multiplexer_type_id = 6;
+}
+
+message ResolvedPinsOrRelays {
+  // List of pin or relay names in the pin or relay group.
+  repeated string pin_or_relay_names = 1;
 }

--- a/ni/measurementlink/sessionmanagement/v1/session_management_service.proto
+++ b/ni/measurementlink/sessionmanagement/v1/session_management_service.proto
@@ -175,12 +175,13 @@ message ReserveSessionsRequest {
 
 message ReserveSessionsResponse{
     // List of information needed to create or use each session for the given pin, site, and instrument type ID.
-    // This field is readonly.
     repeated SessionInformation sessions = 1;
 
     // List of information needed to create or use each multiplexer session for the given pin, site, and instrument type ID.
-    // This field is readonly.
     repeated MultiplexerSessionInformation multiplexer_sessions = 2;
+    
+    // Represents the mapping between pin or relay groups and their respective pin or relay names.
+    map<string, ResolvedPinsOrRelays> group_mappings = 3;
 }
 
 message UnreserveSessionsRequest {
@@ -269,4 +270,9 @@ message GetAllRegisteredMultiplexerSessionsRequest{
 message GetAllRegisteredMultiplexerSessionsResponse{
     // Multiplexer sessions currently registered in the session management service.
     repeated MultiplexerSessionInformation multiplexer_sessions = 1;
+}
+
+message ResolvedPinsOrRelays {
+  // List of pin or relay names in the pin or relay group.
+  repeated string pin_or_relay_names = 1;
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
- Updated `QueryResourceAccessInformationResponse` in `pin_map_service.proto` and `ReserveSessionsResponse` in `session_management_service.proto` to include `group_mappings` .

### Why should this Pull Request be merged?
- Enables Pin and Relay group support in the `SessionManagementService` and `session manager APIs` (LabVIEW and Python) - [Feature 2533922](https://dev.azure.com/ni/DevCentral/_workitems/edit/2533922).

### What testing has been done?
None (`.proto` file changes only).
