### PR TITLE
Update 'EnumerateServicesResponse' to have an 'unreachable' field

### DIFF
--- a/ni/measurementlink/discovery/v1/discovery_service.proto
+++ b/ni/measurementlink/discovery/v1/discovery_service.proto
@@ -136,9 +136,10 @@ message EnumerateServicesRequest {
 message EnumerateServicesResponse {
   // The list of available services which implement the specified service interface.
   repeated ServiceDescriptor available_services = 1;
-  // Information about any unreachable resources. This will be a list of the service classes
-  // that are unreachable. To get extended information about the unreachable resources, use
-  // ResolveService and handle the resulting error.
+  // Information about any unreachable resources. Each string in the list will be a
+  // 'ServiceDescriptor.service_class' entry for each of the unreachable resources.
+  // To get extended information about the unreachable resources, use ResolveService
+  // and handle the resulting error.
   repeated string unreachable = 2;
 }
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR includes an `unreachable` field in the `EnumerateServicesResponse`.  This follows the guidelines given in [AIP-217](https://google.aip.dev/217).  It allows us to return a partial set of results while indicating some resources were unavailable.

### Why should this Pull Request be merged?

Needed to indicate when one or more service repositories (out of many) are unavailable.

### What testing has been done?

None.
