### PR TITLE
Added new ResolveServiceWithInformation API to discovery service

### DIFF
--- a/ni/measurementlink/discovery/v1/discovery_service.proto
+++ b/ni/measurementlink/discovery/v1/discovery_service.proto
@@ -50,14 +50,17 @@ service DiscoveryService {
   // - FAILED_PRECONDITION: More than one service matching the resolve request was found
   rpc ResolveService(ResolveServiceRequest) returns (ServiceLocation);
 
+  // Similar to ResolveService, returns information for the service in addition to the location of the service. 
+  // This is useful if you want to avoid the overhead of having to call EnumerateServices to get this information as part of
+  // resolution of the service. See ResolveService for additional documentation related to resolving the service.
+  rpc ResolveServiceWithInformation(ResolveServiceWithInformationRequest) returns (ResolveServiceWithInformationResponse);
+
   // Enumerate all compute nodes that have registered themselves in the current session.
   // These compute nodes are targets available for execution of services.
   // A compute node can be used as an argument to the ResolveService method to
   // get the service location for a service running on that compute node.
   rpc EnumerateComputeNodes(EnumerateComputeNodesRequest) returns (EnumerateComputeNodesResponse);
 
-  // Functions like ResolveService but returns selected measurement service's address and description.
-  rpc ResolveServiceWithInformation(ResolveServiceRequest) returns (ResolveServiceWithInformationResponse);
 }
 
 // Description of a registered service. This information can be used to display information to the user
@@ -163,6 +166,31 @@ message ResolveServiceRequest {
   string deployment_target = 3;
 }
 
+message ResolveServiceWithInformationRequest {
+  // Required. This corresponds to the gRPC Full Name of the service and should match the information
+  // that was supplied in the RegisterServiceRequest message.
+  string provided_interface = 1;
+
+  // Optional. The service "class" that should be matched. If the value of this field is not specified and there
+  // is more than one matching service registered, an error is returned.
+  string service_class = 2;
+
+  // Optional. Indicates the deployment target from which the service should be resolved.
+  // The value of this field can be obtained from the results of the EnumerateComputeNodes method.
+  // If the value of this field is not specified, the service will be resolved from the
+  // local deployment target.  If the service cannot be resolved from the specified deployment
+  // target, an error is returned.
+  string deployment_target = 3;
+}
+
+message ResolveServiceWithInformationResponse {
+  // The canonical location information of the service.
+  ServiceLocation service_location = 1;
+
+  // The description of the service.
+  ServiceDescriptor service_descriptor = 2;
+}
+
 // Represents a location capable resolving and running a service.
 message ComputeNodeDescriptor {
   // The resolvable name of the compute node.
@@ -179,12 +207,4 @@ message EnumerateComputeNodesRequest {
 message EnumerateComputeNodesResponse {
   // The list of compute nodes that have registered themselves in the current session.
   repeated ComputeNodeDescriptor compute_nodes = 1;
-}
-
-message ResolveServiceWithInformationResponse {
-  // The canonical location information for the service.
-  ServiceLocation service_location = 1;
-
-  // Url which provides descriptive information about the service.
-  string service_description_url = 2;
 }

--- a/ni/measurementlink/discovery/v1/discovery_service.proto
+++ b/ni/measurementlink/discovery/v1/discovery_service.proto
@@ -186,5 +186,5 @@ message ResolveServiceWithInformationResponse {
   ServiceLocation service_location = 1;
 
   // Url which provides descriptive information about the service.
-  string service_description = 2;
+  string service_description_url = 2;
 }

--- a/ni/measurementlink/discovery/v1/discovery_service.proto
+++ b/ni/measurementlink/discovery/v1/discovery_service.proto
@@ -56,9 +56,8 @@ service DiscoveryService {
   // get the service location for a service running on that compute node.
   rpc EnumerateComputeNodes(EnumerateComputeNodesRequest) returns (EnumerateComputeNodesResponse);
 
-  // Returns the selected measurement service's address and descriptor.
-  // Functions like ResolveService but returns ServiceDescriptor along with Location.
-  rpc ResolveServiceWithInformation(ResolveServiceWithInformationRequest) returns (ResolveServiceWithInformationResponse);
+  // Functions like ResolveService but returns selected measurement service's address and description.
+  rpc ResolveServiceWithInformation(ResolveServiceRequest) returns (ResolveServiceWithInformationResponse);
 }
 
 // Description of a registered service. This information can be used to display information to the user
@@ -182,27 +181,10 @@ message EnumerateComputeNodesResponse {
   repeated ComputeNodeDescriptor compute_nodes = 1;
 }
 
-message ResolveServiceWithInformationRequest {
-  // Required. This corresponds to the gRPC Full Name of the service and should match the information
-  // that was supplied in the RegisterServiceRequest message.
-  string provided_interface = 1;
-
-  // Optional. The service "class" that should be matched. If the value of this field is not specified and there
-  // is more than one matching service registered, an error is returned.
-  string service_class = 2;
-
-  // Optional. Indicates the deployment target from which the service should be resolved.
-  // The value of this field can be obtained from the results of the EnumerateComputeNodes method.
-  // If the value of this field is not specified, the service will be resolved from the
-  // local deployment target.  If the service cannot be resolved from the specified deployment
-  // target, an error is returned.
-  string deployment_target = 3;
-}
-
 message ResolveServiceWithInformationResponse {
   // The canonical location information for the service.
   ServiceLocation service_location = 1;
 
   // The description of the service.
-  ServiceDescriptor service_descriptor = 2;
+  string service_description = 2;
 }

--- a/ni/measurementlink/discovery/v1/discovery_service.proto
+++ b/ni/measurementlink/discovery/v1/discovery_service.proto
@@ -55,6 +55,10 @@ service DiscoveryService {
   // A compute node can be used as an argument to the ResolveService method to
   // get the service location for a service running on that compute node.
   rpc EnumerateComputeNodes(EnumerateComputeNodesRequest) returns (EnumerateComputeNodesResponse);
+
+  // Returns the selected measurement service's address and descriptor.
+  // Functions like ResolveService but returns ServiceDescriptor along with Location.
+  rpc ResolveServiceWithInformation(ResolveServiceWithInformationRequest) returns (ResolveServiceWithInformationResponse);
 }
 
 // Description of a registered service. This information can be used to display information to the user
@@ -176,4 +180,29 @@ message EnumerateComputeNodesRequest {
 message EnumerateComputeNodesResponse {
   // The list of compute nodes that have registered themselves in the current session.
   repeated ComputeNodeDescriptor compute_nodes = 1;
+}
+
+message ResolveServiceWithInformationRequest {
+  // Required. This corresponds to the gRPC Full Name of the service and should match the information
+  // that was supplied in the RegisterServiceRequest message.
+  string provided_interface = 1;
+
+  // Optional. The service "class" that should be matched. If the value of this field is not specified and there
+  // is more than one matching service registered, an error is returned.
+  string service_class = 2;
+
+  // Optional. Indicates the deployment target from which the service should be resolved.
+  // The value of this field can be obtained from the results of the EnumerateComputeNodes method.
+  // If the value of this field is not specified, the service will be resolved from the
+  // local deployment target.  If the service cannot be resolved from the specified deployment
+  // target, an error is returned.
+  string deployment_target = 3;
+}
+
+message ResolveServiceWithInformationResponse {
+  // The canonical location information for the service.
+  ServiceLocation service_location = 1;
+
+  // The description of the service.
+  ServiceDescriptor service_descriptor = 2;
 }

--- a/ni/measurementlink/discovery/v1/discovery_service.proto
+++ b/ni/measurementlink/discovery/v1/discovery_service.proto
@@ -60,7 +60,6 @@ service DiscoveryService {
   // A compute node can be used as an argument to the ResolveService method to
   // get the service location for a service running on that compute node.
   rpc EnumerateComputeNodes(EnumerateComputeNodesRequest) returns (EnumerateComputeNodesResponse);
-
 }
 
 // Description of a registered service. This information can be used to display information to the user

--- a/ni/measurementlink/discovery/v1/discovery_service.proto
+++ b/ni/measurementlink/discovery/v1/discovery_service.proto
@@ -185,6 +185,6 @@ message ResolveServiceWithInformationResponse {
   // The canonical location information for the service.
   ServiceLocation service_location = 1;
 
-  // The description of the service.
+  // Url which provides descriptive information about the service.
   string service_description = 2;
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Adds new API `ResolveServiceWithInformation` to Discovery Service. This is needed for this **[Feature 2637011](https://dev.azure.com/ni/DevCentral/_workitems/edit/2637011): Add info button to link documentation in the MeasLink measurement header**.

### Why should this Pull Request be merged?
To get the `ServiceDescriptor` of the selected measurement as mentioned [here](https://dev.azure.com/ni/DevCentral/_git/ASW?path=/Specs/Test%20Automation%20Frameworks/F2637011_InfoButtonForMeasurementDocumentation/F2637011_InfoButtonForMeasurementDocumentation.md&version=GCbae6f2875fc99c9b7aa9b231eb0d7540acf4ad3e&_a=preview&anchor=discovery-service-changes). 

### What testing has been done?
PR checks
