### PR TITLE
Add support for versioned services to DiscoveryService API

### DIFF
--- a/ni/measurementlink/discovery/v1/discovery_service.proto
+++ b/ni/measurementlink/discovery/v1/discovery_service.proto
@@ -94,6 +94,21 @@ message ServiceDescriptor {
   //   - Expected format: serialized JSON string of an array of strings
   //   - Example: "[\"powerup\", \"current\"]"
   map<string, string> annotations = 5;
+
+  // This field is used differently based on the message in which it is used.
+  //
+  // When used in a RegisterServiceRequest, this field must contain a single
+  // version, and that version must follow the major.minor.patch format.
+  // The version 0.0.1 is reserved for internal use, and cannot be specified.
+  // If no version is specified, the version 0.0.1 will be used internally
+  // for the registered service.
+  //
+  // When returned from EnumerateServicesResponse, this field will contain the
+  // list of versions that are available for the associated service.
+  //
+  // When returned from ResolveServiceWithInformationResponse, this field will
+  // contain the version of the resolved service.
+  repeated string versions = 6;
 }
 
 // Represents the location of a service. The location generally includes the IP address and port number for the service
@@ -170,6 +185,9 @@ message ResolveServiceRequest {
   // local deployment target.  If the service cannot be resolved from the specified deployment
   // target, an error is returned.
   string deployment_target = 3;
+
+  // Optional. The version of the service to resolve. If not specified, the latest version will be resolved.
+  string version = 4;
 }
 
 message ResolveServiceWithInformationRequest {
@@ -187,6 +205,9 @@ message ResolveServiceWithInformationRequest {
   // local deployment target.  If the service cannot be resolved from the specified deployment
   // target, an error is returned.
   string deployment_target = 3;
+
+  // Optional. The version of the service to resolve. If not specified, the latest version will be resolved.
+  string version = 4;
 }
 
 message ResolveServiceWithInformationResponse {


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR adds support for versioned services to the DiscoveryService API.

- You can now specify a version (via `ServiceDescriptor`) when registering a service.
- Versions are returned via `ServiceDescriptor` when enumerating services
- A version can be specified when resolving a service.

### Why should this Pull Request be merged?

As we add support for versioned services, DiscoveryService must be version aware.

### What testing has been done?

None.
