### PR TITLE
Remove Curtis from code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Default code owners for the repository
-* @bkeryan @cumitche 
+* @bkeryan @dixonjoel 
 
 # Default code owners by file type
-*.md @bkeryan @cumitche @nstokes-nati
+*.md @bkeryan @dixonjoel @nstokes-nati
 *.proto @ccifra @jasonmreding
 
 # Code owners for specific APIs (e.g. /ni/grpcdevice/)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update code owners to remove Curtis. He's on another team now.

### Why should this Pull Request be merged?

Keep code owners current.

### What testing has been done?

None
