### PR TITLE
Update docs to indicate service class must be globally unique

### DIFF
--- a/ni/measurementlink/discovery/v1/discovery_service.proto
+++ b/ni/measurementlink/discovery/v1/discovery_service.proto
@@ -75,7 +75,7 @@ message ServiceDescriptor {
   // Registration can use the gRPC metadata to provide these names.
   repeated string provided_interfaces = 3;
 
-  // Required. The "class" of a service. The value of this field should be unique for a given interface in provided_interfaces.
+  // Required. The "class" of a service. The value of this field should be unique for all services.
   // In effect, the .proto service declaration defines the interface, and this field defines a class or concrete type of the interface.
   string service_class = 4;
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Following changes in the `DiscoveryService` implementation of this `.proto` file, it's no longer true that "service class" only has to be unique for a given provided interface.  Instead, "service class" should always be unique.

### Why should this Pull Request be merged?

Updating docs to match actual behavior.

### What testing has been done?

None.
