### PR TITLE
Add parametric data proto file

### DIFF
--- a/ni/protobuf/types/parametric_data.proto
+++ b/ni/protobuf/types/parametric_data.proto
@@ -1,0 +1,62 @@
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+syntax = "proto3";
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+package ni.protobuf.types;
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+option csharp_namespace = "NationalInstruments.Protobuf.Types";
+option go_package = "types";
+option java_multiple_files = true;
+option java_outer_classname = "ParametricDataProto";
+option java_package = "com.ni.protobuf.types";
+option objc_class_prefix = "NIPT";
+option php_namespace = "NI\\PROTOBUF\\TYPES";
+option ruby_package = "NI::Protobuf::Types";
+
+message ParametricDataValue {
+  oneof value {
+    double double_value = 1;
+    bool bool_value = 2;
+    string string_value = 3;
+    int32 int_value = 4;
+  }
+  string label = 5;
+  string unit = 6;
+}
+
+message ParametricDataValueArray {
+    message DoubleArray {
+        repeated double values = 1;
+    }
+    message BoolArray {
+        repeated bool values = 1;
+    }
+    message StringArray {
+        repeated string values = 1;
+    }
+    message IntArray {
+        repeated int32 values = 1;
+    }
+    oneof value {
+        DoubleArray double_array = 1;
+        BoolArray bool_array = 2;
+        StringArray string_array = 3;
+        IntArray int_array = 4;
+    }
+    string label = 5;
+    string unit = 6;
+}
+
+message ParametricData {
+    ParametricDataValue value = 1;
+    repeated ParametricDataValue parameters = 2;
+}
+
+message ParametricDataArray {
+    ParametricDataValueArray values = 1;
+    repeated ParametricDataValueArray parameters = 2;
+}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds the `parametric_data.proto` file used by the data store service.

### Why should this Pull Request be merged?

While this type has not been fully released yet, it is needed for a LabVIEW client that is in development. Generated grpc-labview code depends on this type, so making it accessible with the other types in the same location is desirable. It will almost certainly live in this repo once it is released and while it is not officially finalized, @nick-beer has said it is probably final and @dixonjoel has approved putting up this pull request to make it available prior to official release.

### What testing has been done?

The data types are used in a C# server and client and work well.
