### PR TITLE
feat: add `GetSessions` API in session_management_service for Session Manager UI

### DIFF
--- a/ni/measurementlink/sessionmanagement/v1/session_management_service.proto
+++ b/ni/measurementlink/sessionmanagement/v1/session_management_service.proto
@@ -74,7 +74,7 @@ service SessionManagementService {
   // Gets all multiplexer sessions currently registered with this service.
   rpc GetAllRegisteredMultiplexerSessions(GetAllRegisteredMultiplexerSessionsRequest) returns (GetAllRegisteredMultiplexerSessionsResponse);
 
-  // Gets all the reserved, registered instrument sessions and registered multiplexer sessions.
+  // Gets all reserved or registered sessions for the specified instrument and multiplexer types.
   rpc GetSessions(GetSessionsRequest) returns (GetSessionsResponse);
 }
 
@@ -105,11 +105,11 @@ message SessionInformation{
   // This field is readonly.
   string instrument_type_id = 4;
 
-  // Indicates whether the session exists in the Session Manager. This indicates whether the session has been created.
+  // Indicates whether the session has been created and registered with the Session Manager.
   // This field is readonly.
   bool session_exists = 5;
 
-  // Indicates whether the session is reserved in the Session Manager.
+  // Indicates whether the session has been reserved with the Session Manager.
   // This field is readonly.
   bool session_reserved = 7;
 
@@ -286,14 +286,16 @@ message ResolvedPinsOrRelays {
 
 message GetSessionsRequest {
   // Optional. Instrument type ID of the instruments.
+  // If unspecified, information for all instrument types is returned.
   string instrument_type_id = 1;
 
   // Optional. User-defined identifier for the multiplexers.
+  // If unspecified, information for all registered multiplexer types is returned.
   string multiplexer_type_id = 2; 
 }
 
 message GetSessionsResponse {
-  // List of reserved, registered instrument sessions.
+  // List of reserved or registered instrument sessions.
   repeated SessionInformation sessions = 1;
 
   // List of registered multiplexer sessions.

--- a/ni/measurementlink/sessionmanagement/v1/session_management_service.proto
+++ b/ni/measurementlink/sessionmanagement/v1/session_management_service.proto
@@ -73,6 +73,9 @@ service SessionManagementService {
 
   // Gets all multiplexer sessions currently registered with this service.
   rpc GetAllRegisteredMultiplexerSessions(GetAllRegisteredMultiplexerSessionsRequest) returns (GetAllRegisteredMultiplexerSessionsResponse);
+
+  // Gets all the reserved, registered instrument sessions and registered multiplexer sessions.
+  rpc GetSessions(GetSessionsRequest) returns (GetSessionsResponse);
 }
 
 message SessionInformation{
@@ -105,6 +108,10 @@ message SessionInformation{
   // Indicates whether the session exists in the Session Manager. This indicates whether the session has been created.
   // This field is readonly.
   bool session_exists = 5;
+
+  // Indicates whether the session is reserved in the Session Manager.
+  // This field is readonly.
+  bool session_reserved = 7;
 
   // List of site and I/O resource mappings with optional multiplexer information for each channel in the channel_list.
   // Each item represents a channel-to-I/O-resource connection for this instrument resource. In the case of shared pins, there is a separate item for each connection.
@@ -275,4 +282,20 @@ message GetAllRegisteredMultiplexerSessionsResponse{
 message ResolvedPinsOrRelays {
   // List of pin or relay names in the pin or relay group.
   repeated string pin_or_relay_names = 1;
+}
+
+message GetSessionsRequest {
+  // Optional. Instrument type ID of the instruments.
+  string instrument_type_id = 1;
+
+  // Optional. User-defined identifier for the multiplexers.
+  string multiplexer_type_id = 2; 
+}
+
+message GetSessionsResponse {
+  // List of reserved, registered instrument sessions.
+  repeated SessionInformation sessions = 1;
+
+  // List of registered multiplexer sessions.
+  repeated MultiplexerSessionInformation multiplexer_sessions = 2; 
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
* Adds a new `GetSessions` API to the `session_management_service.proto`, which will return the list of reserved, registered instrument sessions and registered multiplexer sessions.
* [#AB3105612](https://dev.azure.com/ni/DevCentral/_workitems/edit/3105612)

### Why should this Pull Request be merged?
* For the Session Manager UI [feature](https://dev.azure.com/ni/DevCentral/_workitems/edit/3050274), we need to display the list of reserved, registered instruments and registered multiplexer sessions on the UI. Therefore, a new API (`GetSessions`) is being introduced to get the needed list of sessions from the Session Management Service.

### What testing has been done?
The PR pipeline should pass. The implementation changes will follow in the upcoming weeks.
