### PR TITLE
Add the ScalarData type to ni-apis.

### DIFF
--- a/ni/protobuf/types/attribute_value.proto
+++ b/ni/protobuf/types/attribute_value.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package ni.protobuf.types;
+
+option csharp_namespace = "NationalInstruments.Protobuf.Types";
+option go_package = "types";
+option java_multiple_files = true;
+option java_outer_classname = "AttributeValueProto";
+option java_package = "com.ni.protobuf.types";
+option objc_class_prefix = "NIPT";
+option php_namespace = "NI\\PROTOBUF\\TYPES";
+option ruby_package = "NI::Protobuf::Types";
+
+message AttributeValue
+{
+  // The kind of attribute value.
+  oneof attribute
+  {
+    // Represents a bool attribute.
+    bool bool_value = 1;
+
+    // Represents an integer attribute.
+    int32 integer_value = 2;
+
+    // Represents a double attribute.
+    double double_value = 3;
+
+    // Represents a string attribute.
+    string string_value = 4;
+  }
+}

--- a/ni/protobuf/types/scalar.proto
+++ b/ni/protobuf/types/scalar.proto
@@ -13,9 +13,17 @@ option objc_class_prefix = "NIPT";
 option php_namespace = "NI\\PROTOBUF\\TYPES";
 option ruby_package = "NI::Protobuf::Types";
 
-message Scalar {
+// A scalar data class, which encapsulates a scalar value and associated
+// attributes, including units.
+message Scalar
+{
+  // The names and values of all scalar attributes.
+  // A scalar attribute is metadata attached to a scalar.
+  // It is represented in this message as a map associating the name of
+  // the attribute with the value described by AttributeValue.
   map<string, AttributeValue> attributes = 1;
 
+  // The scalar value. It can be one of these types: double, int32, bool, string.
   oneof value {
     double double_value = 2;
     int32 int32_value = 3;

--- a/ni/protobuf/types/scalar.proto
+++ b/ni/protobuf/types/scalar.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package ni.protobuf.types;
 
+import "ni/protobuf/types/attribute_value.proto";
+
 option csharp_namespace = "NationalInstruments.Protobuf.Types";
 option go_package = "types";
 option java_multiple_files = true;
@@ -12,31 +14,12 @@ option php_namespace = "NI\\PROTOBUF\\TYPES";
 option ruby_package = "NI::Protobuf::Types";
 
 message Scalar {
-  map<string, ScalarAttributeValue> attributes = 1;
+  map<string, AttributeValue> attributes = 1;
 
   oneof value {
     double double_value = 2;
     int32 int32_value = 3;
     bool bool_value = 4;
     string string_value = 5;
-  }
-}
-
-message ScalarAttributeValue
-{
-  // The kind of attribute value.
-  oneof attribute
-  {
-    // Represents a bool attribute.
-    bool bool_value = 1;
-
-    // Represents an integer attribute.
-    int32 integer_value = 2;
-
-    // Represents a double attribute.
-    double double_value = 3;
-
-    // Represents a string attribute.
-    string string_value = 4;
   }
 }

--- a/ni/protobuf/types/scalar.proto
+++ b/ni/protobuf/types/scalar.proto
@@ -11,13 +11,32 @@ option objc_class_prefix = "NIPT";
 option php_namespace = "NI\\PROTOBUF\\TYPES";
 option ruby_package = "NI::Protobuf::Types";
 
-message ScalarData {
-  string units = 1;
+message Scalar {
+  map<string, ScalarAttributeValue> attributes = 1;
 
   oneof value {
     double double_value = 2;
     int32 int32_value = 3;
     bool bool_value = 4;
     string string_value = 5;
+  }
+}
+
+message ScalarAttributeValue
+{
+  // The kind of attribute value.
+  oneof attribute
+  {
+    // Represents a bool attribute.
+    bool bool_value = 1;
+
+    // Represents an integer attribute.
+    int32 integer_value = 2;
+
+    // Represents a double attribute.
+    double double_value = 3;
+
+    // Represents a string attribute.
+    string string_value = 4;
   }
 }

--- a/ni/protobuf/types/scalar.proto
+++ b/ni/protobuf/types/scalar.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package ni.protobuf.types;
+
+option csharp_namespace = "NationalInstruments.Protobuf.Types";
+option go_package = "types";
+option java_multiple_files = true;
+option java_outer_classname = "ScalarProto";
+option java_package = "com.ni.protobuf.types";
+option objc_class_prefix = "NIPT";
+option php_namespace = "NI\\PROTOBUF\\TYPES";
+option ruby_package = "NI::Protobuf::Types";
+
+message ScalarData {
+  string units = 1;
+
+  oneof value {
+    double double_value = 2;
+    int32 int32_value = 3;
+    bool bool_value = 4;
+    string string_value = 5;
+  }
+}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Adds the `Scalar` type to the `ni-apis` repo. It had been temporarily added to a different repo to enable development. Now that we are working on consolidating the types into `ni-apis`, we want to add it here.
- `Scalar` represents a scalar value with units and extended attributes.
- Adds the `AttributeValue` type to `ni-apis` to be used as the type of the value of the `attributes` map inside `Scalar`
   - `AttributeValue` will also be used by the `Vector` type once that is added.
   - `DoubleAnalogWaveform` will continue to use `WaveformAttributeType`.
- I will remove `scalar.proto` from the other repo in a separate PR.

### Why should this Pull Request be merged?

Submitting this file will allow us to generate stubs for this proto file and begin moving grpc conversion functions into the correct location.

### What testing has been done?

None
