### PR TITLE
Add the digital waveform type to waveform.proto.

### DIFF
--- a/ni/protobuf/types/waveform.proto
+++ b/ni/protobuf/types/waveform.proto
@@ -30,8 +30,7 @@ option ruby_package = "NI::Protobuf::Types";
 // For additional information on waveform attributes, please visit https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/get-waveform-attribute.html
 
 // An analog waveform, which encapsulates analog data as doubles and timing information.
-message DoubleAnalogWaveform
-{
+message DoubleAnalogWaveform {
   // The time of the first sample in y_data.
   PrecisionTimestamp t0 = 1;
 
@@ -119,8 +118,7 @@ message DoubleSpectrum {
 }
 
 // Waveform Attribute Value
-message WaveformAttributeValue
-{
+message WaveformAttributeValue {
   // The kind of attribute value.
   oneof attribute
   {
@@ -139,8 +137,7 @@ message WaveformAttributeValue
 }
 
 // A digital waveform, which encapsulates digital data as integers, timing information, and extended properties.
-message DigitalWaveform
-{
+message DigitalWaveform {
   // The time of the first sample in y_data.
   PrecisionTimestamp t0 = 1;
 

--- a/ni/protobuf/types/waveform.proto
+++ b/ni/protobuf/types/waveform.proto
@@ -147,19 +147,16 @@ message DigitalWaveform
   // The time interval in seconds between data points in the waveform.
   double dt = 2;
 
-  // The data values of the waveform.
-  repeated DigitalSample y_data = 3;
+  // The number of signals in each sample of data.
+  int32 signal_count = 3;
+
+  // The data values of the waveform. This data is a flattened array of bytes
+  // that are ordered such that each signal_count bytes represents a sample.
+  bytes y_data = 4;
 
   // The names and values of all waveform attributes.
   // See the comment at near the top of this file for more details.
-  map<string, WaveformAttributeValue> attributes = 4;
-}
-
-// A digital sample, which consists of one or more digital signals.
-// We only need 8 bits to represent a digital state, but grpc doesn't define anything smaller than int32.
-// However, when serialized, these int32s will be optimized into a single byte each.
-message DigitalSample {
-   repeated int32 signals = 1;
+  map<string, WaveformAttributeValue> attributes = 5;
 }
 
 // Scaling information which can be used to convert unscaled data represented by this waveform to scaled data.

--- a/ni/protobuf/types/waveform.proto
+++ b/ni/protobuf/types/waveform.proto
@@ -138,6 +138,30 @@ message WaveformAttributeValue
   }
 }
 
+// A digital waveform, which encapsulates digital data as integers, timing information, and extended properties.
+message DigitalWaveform
+{
+  // The time of the first sample in y_data.
+  PrecisionTimestamp t0 = 1;
+
+  // The time interval in seconds between data points in the waveform.
+  double dt = 2;
+
+  // The data values of the waveform.
+  repeated DigitalSample y_data = 3;
+
+  // The names and values of all waveform attributes.
+  // See the comment at near the top of this file for more details.
+  map<string, WaveformAttributeValue> attributes = 4;
+}
+
+// A digital sample, which consists of one or more digital signals.
+// We only need 8 bits to represent a digital state, but grpc doesn't define anything smaller than int32.
+// However, when serialized, these int32s will be optimized into a single byte each.
+message DigitalSample {
+   repeated int32 signals = 1;
+}
+
 // Scaling information which can be used to convert unscaled data represented by this waveform to scaled data.
 message Scale {
   oneof mode {


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Adds a new message type `DigitalWaveform` to waveform.proto.
- This message type contains a flattened 2D array specified as `bytes` along with `signal_count` that can be used to unflatten the array.
- The digital waveform has the same timing and extended properties fields as an analog waveform.

### Why should this Pull Request be merged?

Implements [AB#3200675](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3200675)

### What testing has been done?

None
