### PR TITLE
Add the Vector type to ni-apis.

### DIFF
--- a/ni/protobuf/types/vector.proto
+++ b/ni/protobuf/types/vector.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+
+package ni.protobuf.types;
+
+import "ni/protobuf/types/attribute_value.proto";
+
+option csharp_namespace = "NationalInstruments.Protobuf.Types";
+option go_package = "types";
+option java_multiple_files = true;
+option java_outer_classname = "VectorProto";
+option java_package = "com.ni.protobuf.types";
+option objc_class_prefix = "NIPT";
+option php_namespace = "NI\\PROTOBUF\\TYPES";
+option ruby_package = "NI::Protobuf::Types";
+
+// A vector data class, which encapsulates an array of values and associated
+// attributes, including units.
+message Vector {
+  message DoubleArray {
+    repeated double values = 1;
+  }
+  message Int32Array {
+    repeated int32 values = 1;
+  }
+  message BoolArray {
+    repeated bool values = 1;
+  }
+  message StringArray {
+    repeated string values = 1;
+  }
+
+  // The names and values of all vector attributes.
+  // A vector attribute is metadata attached to a vector.
+  // It is represented in this message as a map associating the name of
+  // the attribute with the value described by AttributeValue.
+  map<string, AttributeValue> attributes = 1;
+
+  // Required: The value of the vector data array.
+  oneof value {
+    DoubleArray double_array = 2;
+    Int32Array int32_array = 3;
+    BoolArray bool_array = 4;
+    StringArray string_array = 5;
+  }
+}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Creates a new type in ni-apis named `Vector`. This type is equivalent to the [ScalarArray](https://dev.azure.com/ni/DevCentral/_git/ASW?path=/Source/Protos/ni/measurements/data/v1/data_store.proto&version=GBmain&line=206&lineEnd=230&lineStartColumn=1&lineEndColumn=2&lineStyle=plain&_a=contents) type from datastore except it has an attribute map instead of `units`. The value for units will be stored in the attribute map, similar to the [Scalar ni-apis type](https://github.com/ni/ni-apis/blob/6d4837bc7b6757ae365853a28d175be506a14474/ni/protobuf/types/scalar.proto#L18).


### Why should this Pull Request be merged?

Part of AB#3119937

### What testing has been done?

None
