### PR TITLE
Remove comment boundaries that cause sphinx errors during doc gen.

### DIFF
--- a/ni/protobuf/types/array.proto
+++ b/ni/protobuf/types/array.proto
@@ -17,7 +17,6 @@ option objc_class_prefix = "NIPT";
 option php_namespace = "NI\\PROTOBUF\\TYPES";
 option ruby_package = "NI::Protobuf::Types";
 
-//---------------------------------------------------------------------
 // Defines a 2D array of values. The 2D array is stored as a repeated field of
 // the appropriate element type, a 1D array. It is stored in row major order.
 //
@@ -39,7 +38,6 @@ option ruby_package = "NI::Protobuf::Types";
 //  The length of the 'data' field must be equal to rows * columns.
 //  If it is not, implementations should treat this state as invalid
 //  and return INVALID_ARGUMENT status code if appropriate.
-//---------------------------------------------------------------------
 message Double2DArray
 {
   int32 rows = 1;


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove the lines of hyphens above and below the array message comment. These lines are not valid markdown or RestructuredText, so they cause errors when trying to generate the documentation for the stub python file generated from this proto file.

See: https://github.com/ni/ni-apis-python/actions/runs/16421578213/job/46401369362?pr=28

### Why should this Pull Request be merged?

Allows sphinx to properly create documentation for the python stubs generated from this proto file. This is only a comment update, so there are no functional changes in this PR.

### What testing has been done?

I manually removed these two lines from the generated python stub and re-ran the document generation and it got rid of the errors/warnings.
