### PR TITLE
Move nested array messages out of Vector for reuse.

### DIFF
--- a/ni/protobuf/types/array.proto
+++ b/ni/protobuf/types/array.proto
@@ -17,6 +17,31 @@ option objc_class_prefix = "NIPT";
 option php_namespace = "NI\\PROTOBUF\\TYPES";
 option ruby_package = "NI::Protobuf::Types";
 
+// An array of doubles
+message DoubleArray {
+  repeated double values = 1;
+}
+
+// An array of 32-bit integers
+message Int32Array {
+  repeated int32 values = 1;
+}
+
+// An array of booleans
+message BoolArray {
+  repeated bool values = 1;
+}
+
+// An array of strings
+message StringArray {
+  repeated string values = 1;
+}
+
+// An array of bytes collections
+message BytesArray {
+  repeated bytes values = 1;
+}
+
 // A 2D array of doubles.
 //
 // 2D arrays are stored as a repeated field of the appropriate element type,

--- a/ni/protobuf/types/vector.proto
+++ b/ni/protobuf/types/vector.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package ni.protobuf.types;
 
+import "ni/protobuf/types/array.proto";
 import "ni/protobuf/types/attribute_value.proto";
 
 option csharp_namespace = "NationalInstruments.Protobuf.Types";
@@ -15,21 +16,6 @@ option ruby_package = "NI::Protobuf::Types";
 
 // A vector value with associated attributes, such as units.
 message Vector {
-  // These nested messages are only for use by Vector. They should not be
-  // used outside of the Vector context.
-  message DoubleArray {
-    repeated double values = 1;
-  }
-  message Int32Array {
-    repeated int32 values = 1;
-  }
-  message BoolArray {
-    repeated bool values = 1;
-  }
-  message StringArray {
-    repeated string values = 1;
-  }
-
   // The names and values of all vector attributes.
   //
   // A vector attribute is metadata attached to a vector.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Moves the nested array messages out of `Vector` and into `array.proto` so that they can be used outside of the `Vector` context.
- Add a new array `BytesArray` that contains `repeated bytes`.
- Updates `vector.proto` to include `array.proto` and use the array message types from their new location.

### Why should this Pull Request be merged?

Previously, the python panels were defining these array types themselves. In order to continue to allow python panels to accept standard list/set/collection types, we need the array types. Re-using the types from `Vector` is better than creating duplicate array messages.

### What testing has been done?

None
