### PR TITLE
[US3094407] Add Attributes to DoubleXYData

### DIFF
--- a/ni/protobuf/types/xydata.proto
+++ b/ni/protobuf/types/xydata.proto
@@ -8,6 +8,9 @@ package ni.protobuf.types;
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
+
+import "ni/protobuf/types/attribute_value.proto";
+
 option csharp_namespace = "NationalInstruments.Protobuf.Types";
 option go_package = "types";
 option java_multiple_files = true;
@@ -26,4 +29,11 @@ message DoubleXYData
 {
   repeated double x_data = 1;
   repeated double y_data = 2;
+  
+  // The names and values of all xy data attributes.
+  //
+  // An attribute is metadata attached to a xy data.
+  // It is represented in this message as a map associating the name of
+  // the attribute with the value described by AttributeValue.
+  map<string, AttributeValue> attributes = 3;
 }


### PR DESCRIPTION
Add Attributes to `DoubleXYData`

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Adds a map of `AttributeValues` to `DoubleXYData`, similar to what is already done with `Scalar` and `Vector`.

### Why should this Pull Request be merged?

[US3094407](https://dev.azure.com/ni/DevCentral/_backlogs/backlog/SW%20Intelligent%20Test%20Vision%20(ITV)/Epics%20and%20Deliverables?workitem=3094407)

### What testing has been done?
N/A
