### PR TITLE
Create a PrecisionDuration protobuf message

### DIFF
--- a/ni/protobuf/types/precision_duration.proto
+++ b/ni/protobuf/types/precision_duration.proto
@@ -1,0 +1,33 @@
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+syntax = "proto3";
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+package ni.protobuf.types;
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+option csharp_namespace = "NationalInstruments.Protobuf.Types";
+option go_package = "types";
+option java_multiple_files = true;
+option java_outer_classname = "PrecisionDurationProto";
+option java_package = "com.ni.protobuf.types";
+option objc_class_prefix = "NIPT";
+option php_namespace = "NI\\PROTOBUF\\TYPES";
+option ruby_package = "NI::Protobuf::Types";
+
+// Represents a duration of time expressed in NI Binary Time Format (NI-BTF).
+//
+// https://www.ni.com/docs/en-US/bundle/labwindows-cvi/page/cvi/libref/ni-btf.htm
+// NI-BTF stores time values in Coordinated Universal Time (UTC) format.
+// A PrecisionDuration is encoded as a count of seconds and fractions of seconds at
+// 2^-64 resolution.
+message PrecisionDuration
+{
+  // The number of seconds.
+  int64 seconds = 1;
+
+  // Non-negative fractions of a second at 2^-64 resolution.
+  uint64 fractional_seconds = 2;
+}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Creates a `PrecisionDuration` protobuf type that is similar in structure to `PrecisionTimestamp`. This new protobuf message will store data that is converted from `bintime.TimeDelta` and `hightime.timedelta` for communication over GRPC.

### Why should this Pull Request be merged?

Implements the protobuf message type for AB#3164818

### What testing has been done?

None
