### PR TITLE
Fix documentation formatting for Python docs generation

### DIFF
--- a/ni/measurementlink/pinmap/v1/pin_map_service.proto
+++ b/ni/measurementlink/pinmap/v1/pin_map_service.proto
@@ -83,13 +83,16 @@ message QueryPinsRequest {
   string pin_map_id = 1;
 
   // Optional. Filter pins by instrument type.
+
   // Pin maps have built in instrument definitions using the following NI driver based instrument type ids:
-  //      "niDCPower"
-  //      "niDigitalPattern"
-  //      "niScope"
-  //      "niDMM"
-  //      "niDAQmx"
-  //      "niFGen"
+
+  // - "niDCPower"
+  // - "niDigitalPattern"
+  // - "niScope"
+  // - "niDMM"
+  // - "niDAQmx"
+  // - "niFGen"
+
   // For custom instruments the user defined instrument type id is defined in the pin map file.
   string instrument_type_id = 2;
 }

--- a/ni/measurementlink/sessionmanagement/v1/session_management_service.proto
+++ b/ni/measurementlink/sessionmanagement/v1/session_management_service.proto
@@ -93,14 +93,17 @@ message SessionInformation{
   string channel_list = 3;
 
   // Instrument type ID to identify which type of instrument the session represents.
+
   // The session management service has built in instrument definitions using the following NI driver based instrument type ids:
-  //      "niDCPower"
-  //      "niDigitalPattern"
-  //      "niScope"
-  //      "niDMM"
-  //      "niDAQmx"
-  //      "niFGen"
-  //      "niRelayDriver"
+
+  // - "niDCPower"
+  // - "niDigitalPattern"
+  // - "niScope"
+  // - "niDMM"
+  // - "niDAQmx"
+  // - "niFGen"
+  // - "niRelayDriver"
+
   // For custom instruments the user defined instrument type id is defined in the pin map file or custom session management plugin service.
   // This field is readonly.
   string instrument_type_id = 4;


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes the spacing of .proto documentation in a couple places so Sphinx documentation generation can succeed in another repo trying to consume these .proto files.

### Why should this Pull Request be merged?

Allows documentation generation without error when consumers are using Sphinx.

### What testing has been done?

Updated my local third_party/ni-apis .proto content to ensure the Sphinx build would complete locally without errors after these changes.
