### PR TITLE
Restore annotations fields that were mistakenly removed

### DIFF
--- a/ni/measurementlink/sessionmanagement/v1/session_management_service.proto
+++ b/ni/measurementlink/sessionmanagement/v1/session_management_service.proto
@@ -149,6 +149,11 @@ message SessionInformation{
   // This field is empty for any SessionInformation returned from ReserveAllRegisteredSessions.
   // This field is readonly.
   repeated ChannelMapping channel_mappings = 6;
+
+  // Optional. A set of annotations attached to the session.
+  //
+  // For example, the annotations can provide a description of the session or identify who reserved a session.
+  map<string, string> annotations = 8;
 }
 
 message ChannelMapping {
@@ -185,6 +190,11 @@ message MultiplexerSessionInformation {
   // Indicates whether the session exists in the Session Manager. This indicates whether the session has been created.
   // This field is readonly.
   bool session_exists = 4;
+
+  // Optional. A set of annotations attached to the session.
+  //
+  // For example, the annotations can provide a description of the session or identify who reserved a session.
+  map<string, string> annotations = 5;
 }
 
 message ReserveSessionsRequest {
@@ -212,6 +222,11 @@ message ReserveSessionsRequest {
   // Optional. Timeout for the reservation request.
   // Allowed values: 0 (non-blocking, fails immediately if resources cannot be reserved), -1 (infinite timeout), or any other positive numeric value (wait for that number of milliseconds)
   int32 timeout_in_milliseconds = 4;
+
+  // Optional. A set of annotations to add to the session for the duration of the reservation.
+  //
+  // These annotations will automatically be cleared when the session is unreserved.
+  map<string, string> annotations = 5;
 }
 
 message ReserveSessionsResponse{
@@ -268,6 +283,11 @@ message ReserveAllRegisteredSessionsRequest {
   //
   // For custom instruments the user defined instrument type id is defined in the pin map file or custom session management plugin service.
   string instrument_type_id = 2;
+
+  // Optional. A set of annotations to add to the session for the duration of the reservation.
+  //
+  // These annotations will automatically be cleared when the session is unreserved.
+  map<string, string> annotations = 3;
 }
 
 message ReserveAllRegisteredSessionsResponse{


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Restore annotations fields removed in #114.

### Why should this Pull Request be merged?

Mistaken removal

### What testing has been done?

None
