### PR TITLE
Update DataStore to be able to store a digital waveform

### DIFF
--- a/ni/measurements/data/v1/data_store.proto
+++ b/ni/measurements/data/v1/data_store.proto
@@ -208,6 +208,7 @@ message PublishableData {
     ni.protobuf.types.DoubleComplexWaveform double_complex_waveform = 7;
     ni.protobuf.types.I16ComplexWaveform i16_complex_waveform = 8;
     ni.protobuf.types.DoubleSpectrum double_spectrum = 9;
+    ni.protobuf.types.DigitalWaveform digital_waveform = 10;
   }
 }
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds `DigitalWaveform` to the `oneof` for `PublishableData`.

### Why should this Pull Request be merged?

Implements part of [AB#3232466](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3232466)

### What testing has been done?

None
