### PR TITLE
Add missing field to MDS registration schema

### DIFF
--- a/ni/measurements/metadata/v1/registration.schema.json
+++ b/ni/measurements/metadata/v1/registration.schema.json
@@ -314,6 +314,13 @@
           "type": "string",
           "description": "The part number of the UUT"
         },
+        "manufacturers": {
+          "type": "array",
+          "description": "List of manufacturers of the UUT",
+          "items": {
+            "type": "string"
+          }
+        },
         "link": {
           "type": "string",
           "description": "A URI to a resource that further describes this UUT"

--- a/ni/measurements/metadata/v1/registration.schema.json
+++ b/ni/measurements/metadata/v1/registration.schema.json
@@ -118,12 +118,12 @@
           "type": "string",
           "description": "A URI to a resource that further describes this hardware item"
         },
+        "extension": {
+          "$ref": "#/definitions/Extension"
+        },
         "schemaId": {
           "type": "string",
           "description": "The unique identifier of the schema that applies to this instance's extension"
-        },
-        "extension": {
-          "$ref": "#/definitions/Extension"
         }
       }
     },
@@ -148,12 +148,12 @@
           "type": "string",
           "description": "A URI to a resource that further describes this operator"
         },
+        "extension": {
+          "$ref": "#/definitions/Extension"
+        },
         "schemaId": {
           "type": "string",
           "description": "The unique identifier of the schema that applies to this instance's extension"
-        },
-        "extension": {
-          "$ref": "#/definitions/Extension"
         }
       }
     },
@@ -178,12 +178,12 @@
           "type": "string",
           "description": "A URI to a resource that further describes this software item"
         },
+        "extension": {
+          "$ref": "#/definitions/Extension"
+        },
         "schemaId": {
           "type": "string",
           "description": "The unique identifier of the schema that applies to this instance's extension"
-        },
-        "extension": {
-          "$ref": "#/definitions/Extension"
         }
       }
     },
@@ -228,12 +228,12 @@
           "type": "string",
           "description": "A URI to a resource that further describes this test adapter"
         },
+        "extension": {
+          "$ref": "#/definitions/Extension"
+        },
         "schemaId": {
           "type": "string",
           "description": "The unique identifier of the schema that applies to this instance's extension"
-        },
-        "extension": {
-          "$ref": "#/definitions/Extension"
         }
       }
     },
@@ -258,12 +258,12 @@
           "type": "string",
           "description": "A URI to a resource that further describes this test"
         },
+        "extension": {
+          "$ref": "#/definitions/Extension"
+        },
         "schemaId": {
           "type": "string",
           "description": "The unique identifier of the schema that applies to this instance's extension"
-        },
-        "extension": {
-          "$ref": "#/definitions/Extension"
         }
       }
     },
@@ -288,12 +288,12 @@
           "type": "string",
           "description": "A URI to a resource that further describes this test station"
         },
+        "extension": {
+          "$ref": "#/definitions/Extension"
+        },
         "schemaId": {
           "type": "string",
           "description": "The unique identifier of the schema that applies to this instance's extension"
-        },
-        "extension": {
-          "$ref": "#/definitions/Extension"
         }
       }
     },
@@ -310,9 +310,9 @@
           "type": "string",
           "description": "The name of the UUT model"
         },
-        "partNumber": {
+        "family": {
           "type": "string",
-          "description": "The part number of the UUT"
+          "description": "The UUT family or product line"
         },
         "manufacturers": {
           "type": "array",
@@ -321,20 +321,20 @@
             "type": "string"
           }
         },
+        "partNumber": {
+          "type": "string",
+          "description": "The part number of the UUT"
+        },
         "link": {
           "type": "string",
           "description": "A URI to a resource that further describes this UUT"
         },
-        "family": {
-          "type": "string",
-          "description": "The UUT family or product line"
+        "extension": {
+          "$ref": "#/definitions/Extension"
         },
         "schemaId": {
           "type": "string",
           "description": "The unique identifier of the schema that applies to this instance's extension"
-        },
-        "extension": {
-          "$ref": "#/definitions/Extension"
         }
       }
     },
@@ -346,6 +346,10 @@
         "alias": {
           "type": "string",
           "description": "Optional alias identifier for referencing this UUT instance from other entities"
+        },
+        "uutAlias": {
+          "type": "string",
+          "description": "Alias reference to the parent UUT model or type"
         },
         "serialNumber": {
           "type": "string",
@@ -367,16 +371,12 @@
           "type": "string",
           "description": "A URI to a resource that further describes this UUT instance"
         },
+        "extension": {
+          "$ref": "#/definitions/Extension"
+        },
         "schemaId": {
           "type": "string",
           "description": "The unique identifier of the schema that applies to this instance's extension"
-        },
-        "uutAlias": {
-          "type": "string",
-          "description": "Alias reference to the parent UUT model or type"
-        },
-        "extension": {
-          "$ref": "#/definitions/Extension"
         }
       }
     },
@@ -389,6 +389,10 @@
           "type": "string",
           "description": "Optional alias identifier for referencing this test description from other entities"
         },
+        "uutAlias": {
+          "type": "string",
+          "description": "Alias reference to the UUT this test is designed for"
+        },
         "name": {
           "type": "string",
           "description": "The name of the test description"
@@ -397,16 +401,12 @@
           "type": "string",
           "description": "A URI to a resource that further describes this test description"
         },
+        "extension": {
+          "$ref": "#/definitions/Extension"
+        },
         "schemaId": {
           "type": "string",
           "description": "The unique identifier of the schema that applies to this instance's extension"
-        },
-        "uutAlias": {
-          "type": "string",
-          "description": "Alias reference to the UUT this test is designed for"
-        },
-        "extension": {
-          "$ref": "#/definitions/Extension"
         }
       }
     }


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Added the missing `manufacturers` field to the `Uut` definition in `registration.schema.json` to match the corresponding field in `metadata_store.proto`. Also verified that no other fields are missing across all entity types in the schema.

### Why should this Pull Request be merged?

This schema is used to validate the CreateFromJsonDocument endpoint in the data store.

### What testing has been done?

JSON schema validates correctly after the change.
Confirmed manufacturers was the only missing field.