### PR TITLE
Add array wrapper proto types for non-scalar batch measurements

### DIFF
--- a/ni/measurements/data/v1/data_store_service.proto
+++ b/ni/measurements/data/v1/data_store_service.proto
@@ -6,8 +6,12 @@ import "ni/protobuf/types/precision_timestamp.proto";
 import "ni/measurements/data/v1/data_store.proto";
 import "ni/protobuf/types/scalar.proto";
 import "ni/protobuf/types/vector.proto";
+import "ni/protobuf/types/vector_wrappers.proto";
 import "ni/protobuf/types/waveform.proto";
+import "ni/protobuf/types/waveform_wrappers.proto";
+import "ni/protobuf/types/digital_waveform_wrappers.proto";
 import "ni/protobuf/types/xydata.proto";
+import "ni/protobuf/types/xydata_wrappers.proto";
 
 option csharp_namespace = "NationalInstruments.Measurements.Data.V1";
 option go_package = "datav1";
@@ -54,7 +58,7 @@ service DataStoreService {
   rpc PublishConditionBatch(PublishConditionBatchRequest) returns (PublishConditionBatchResponse);
   // Publishes a single measurement value associated with a test step.
   rpc PublishMeasurement(PublishMeasurementRequest) returns (PublishMeasurementResponse);
-  // Publishes multiple scalar measurements at once for parametric sweeps.
+  // Publishes multiple measurements at once for parametric sweeps or repeated iterations.
   rpc PublishMeasurementBatch(PublishMeasurementBatchRequest) returns (PublishMeasurementBatchResponse);
 
   // Gets the measurement associated with the given id.
@@ -240,9 +244,26 @@ message PublishMeasurementBatchRequest {
   // For example, a shared name of "Temperature" can be used for associating temperature readings across multiple iterations of publishing.
   string name = 1;
 
-  // Required. The values of the (scalar) measurement being published across N iterations.
+  // Required. The values of the measurement being published across N iterations.
   oneof values {
+    // Scalar values packed into a vector (e.g., N doubles in a DoubleArray).
     ni.protobuf.types.Vector scalar_values = 2;
+    // N vector values, one per iteration.
+    ni.protobuf.types.VectorArrayValue vector_values = 11;
+    // N double-precision analog waveforms, one per iteration.
+    ni.protobuf.types.DoubleAnalogWaveformArrayValue double_analog_waveform_values = 12;
+    // N XY data sets, one per iteration.
+    ni.protobuf.types.DoubleXYDataArrayValue x_y_data_values = 13;
+    // N 16-bit integer analog waveforms, one per iteration.
+    ni.protobuf.types.I16AnalogWaveformArrayValue i16_analog_waveform_values = 14;
+    // N double-precision complex waveforms, one per iteration.
+    ni.protobuf.types.DoubleComplexWaveformArrayValue double_complex_waveform_values = 15;
+    // N 16-bit integer complex waveforms, one per iteration.
+    ni.protobuf.types.I16ComplexWaveformArrayValue i16_complex_waveform_values = 16;
+    // N double-precision spectrums, one per iteration.
+    ni.protobuf.types.DoubleSpectrumArrayValue double_spectrum_values = 17;
+    // N digital waveforms, one per iteration.
+    ni.protobuf.types.DigitalWaveformArrayValue digital_waveform_values = 18;
   }
   // Optional. Any notes to be associated with the captured measurement.
   string notes = 3;

--- a/ni/protobuf/types/digital_waveform_wrappers.proto
+++ b/ni/protobuf/types/digital_waveform_wrappers.proto
@@ -1,0 +1,29 @@
+// Wrappers for the DigitalWaveform message type. These types are useful
+// for embedding in the google.protobuf.Any type or in oneof fields.
+// Their use outside of these scenarios is discouraged.
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+syntax = "proto3";
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+package ni.protobuf.types;
+
+import "ni/protobuf/types/waveform.proto";
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+option csharp_namespace = "NationalInstruments.Protobuf.Types";
+option go_package = "types";
+option java_multiple_files = true;
+option java_outer_classname = "DigitalWaveformWrappersProto";
+option java_package = "com.ni.protobuf.types";
+option objc_class_prefix = "NIPT";
+option php_namespace = "NI\\PROTOBUF\\TYPES";
+option ruby_package = "NI::Protobuf::Types";
+
+// An array of digital waveforms.
+message DigitalWaveformArrayValue {
+   repeated DigitalWaveform waveforms = 1;
+}

--- a/ni/protobuf/types/vector_wrappers.proto
+++ b/ni/protobuf/types/vector_wrappers.proto
@@ -1,0 +1,29 @@
+// Wrappers for the Vector message type. These types are useful
+// for embedding in the google.protobuf.Any type or in oneof fields.
+// Their use outside of these scenarios is discouraged.
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+syntax = "proto3";
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+package ni.protobuf.types;
+
+import "ni/protobuf/types/vector.proto";
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+option csharp_namespace = "NationalInstruments.Protobuf.Types";
+option go_package = "types";
+option java_multiple_files = true;
+option java_outer_classname = "VectorWrappersProto";
+option java_package = "com.ni.protobuf.types";
+option objc_class_prefix = "NIPT";
+option php_namespace = "NI\\PROTOBUF\\TYPES";
+option ruby_package = "NI::Protobuf::Types";
+
+// An array of vectors.
+message VectorArrayValue {
+   repeated Vector vectors = 1;
+}

--- a/ni/protobuf/types/xydata_wrappers.proto
+++ b/ni/protobuf/types/xydata_wrappers.proto
@@ -1,0 +1,29 @@
+// Wrappers for the DoubleXYData message type. These types are useful
+// for embedding in the google.protobuf.Any type or in oneof fields.
+// Their use outside of these scenarios is discouraged.
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+syntax = "proto3";
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+package ni.protobuf.types;
+
+import "ni/protobuf/types/xydata.proto";
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+option csharp_namespace = "NationalInstruments.Protobuf.Types";
+option go_package = "types";
+option java_multiple_files = true;
+option java_outer_classname = "XYDataWrappersProto";
+option java_package = "com.ni.protobuf.types";
+option objc_class_prefix = "NIPT";
+option php_namespace = "NI\\PROTOBUF\\TYPES";
+option ruby_package = "NI::Protobuf::Types";
+
+// An array of XY data sets.
+message DoubleXYDataArrayValue {
+   repeated DoubleXYData xy_data = 1;
+}


### PR DESCRIPTION
### What Changed?

Add three new array wrapper proto types and extend `PublishMeasurementBatchRequest` to support non-scalar value types in batch measurement publishing.

### Implementation Details

**New proto files:**
- `vector_wrappers.proto` — `VectorArrayValue` (repeated Vector)
- `digital_waveform_wrappers.proto` — `DigitalWaveformArrayValue` (repeated DigitalWaveform)
- `xydata_wrappers.proto` — `DoubleXYDataArrayValue` (repeated DoubleXYData)

**Extended `PublishMeasurementBatchRequest`:**
The `oneof values` block now supports 9 types (previously only scalar):
- `scalar_values` (existing)
- `vector_values`, `double_analog_waveform_values`, `x_y_data_values`, `i16_analog_waveform_values`, `double_complex_waveform_values`, `i16_complex_waveform_values`, `double_spectrum_values`, `digital_waveform_values`

This enables the result processor to batch non-scalar measurements (vectors, waveforms, XY data, spectra, digital waveforms) into a single gRPC round-trip instead of one per measurement.

### Testing Done

Proto compilation verified in downstream datastore-service build.