### PR TITLE
Add new waveform message fields to support waveforms with "Relative" or "Irregular" timing.

### DIFF
--- a/ni/protobuf/types/waveform.proto
+++ b/ni/protobuf/types/waveform.proto
@@ -156,6 +156,33 @@ message DigitalWaveform {
   map<string, WaveformAttributeValue> attributes = 5;
 }
 
+// An analog waveform with irregular timing.
+message IrregularDoubleAnalogWaveform {
+  // The timestamps for each sample in y_data. The length of this field and y_data should match.
+  repeated PrecisionTimestamp timestamps = 1;
+  
+  // The waveform values associated with timestamps. The length of this field and timestamps should match.
+  repeated double y_data = 2;
+  
+  // Attribute names and values. See WaveformAttributeValue for more details.
+  map<string, WaveformAttributeValue> attributes = 3;
+}
+
+// An analog waveform with a relative start time.
+message RelativeDoubleAnalogWaveform {
+  // Relative start time in seconds as a double rather than an absolute timestamp.
+  double time_offset = 1;
+
+  // The time interval in seconds between data points in the waveform.
+  double dt = 2;
+
+  // The data values of the waveform.
+  repeated double y_data = 3;
+
+  // Attribute names and values. See WaveformAttributeValue for more details.
+  map<string, WaveformAttributeValue> attributes = 4;
+}
+
 // Scaling information for converting unscaled waveform data to scaled data.
 message Scale {
   oneof mode {

--- a/ni/protobuf/types/waveform.proto
+++ b/ni/protobuf/types/waveform.proto
@@ -39,13 +39,15 @@ message DoubleAnalogWaveform {
   // A timestamp denoting some external stimulus like a trigger.
   //
   // When setting timestamp, you should also always set t0 and time_offset such
-  // that t0 = timestamp + time_offset.
+  // that t0 = timestamp + time_offset. If timestamp is unset, it is inferred
+  // that timestamp is the same as t0.
   PrecisionTimestamp timestamp = 5;
 
   // The offset, in seconds, relative to timestamp when the first sample occurs.
   //
   // When setting time_offset, either both t0 and timestamp should remain unset
-  // or both should be set such that t0 = timestamp + time_offset.
+  // or both should be set such that t0 = timestamp + time_offset. If time_offset
+  // is unset, it is inferred to be 0.
   double time_offset = 6;
 
   // The timestamps for each sample in y_data.
@@ -79,13 +81,15 @@ message I16AnalogWaveform {
   // A timestamp denoting some external stimulus like a trigger.
   //
   // When setting timestamp, you should also always set t0 and time_offset such
-  // that t0 = timestamp + time_offset.
+  // that t0 = timestamp + time_offset. If timestamp is unset, it is inferred
+  // that timestamp is the same as t0.
   PrecisionTimestamp timestamp = 6;
 
   // The offset, in seconds, relative to timestamp when the first sample occurs.
   //
   // When setting time_offset, either both t0 and timestamp should remain unset
-  // or both should be set such that t0 = timestamp + time_offset.
+  // or both should be set such that t0 = timestamp + time_offset. If time_offset
+  // is unset, it is inferred to be 0.
   double time_offset = 7;
 
   // The timestamps for each sample in y_data.
@@ -119,13 +123,15 @@ message DoubleComplexWaveform {
   // A timestamp denoting some external stimulus like a trigger.
   //
   // When setting timestamp, you should also always set t0 and time_offset such
-  // that t0 = timestamp + time_offset.
+  // that t0 = timestamp + time_offset. If timestamp is unset, it is inferred
+  // that timestamp is the same as t0.
   PrecisionTimestamp timestamp = 5;
 
   // The offset, in seconds, relative to timestamp when the first sample occurs.
   //
   // When setting time_offset, either both t0 and timestamp should remain unset
-  // or both should be set such that t0 = timestamp + time_offset.
+  // or both should be set such that t0 = timestamp + time_offset. If time_offset
+  // is unset, it is inferred to be 0.
   double time_offset = 6;
 
   // The timestamps for each sample in y_data.
@@ -162,13 +168,15 @@ message I16ComplexWaveform {
   // A timestamp denoting some external stimulus like a trigger.
   //
   // When setting timestamp, you should also always set t0 and time_offset such
-  // that t0 = timestamp + time_offset.
+  // that t0 = timestamp + time_offset. If timestamp is unset, it is inferred
+  // that timestamp is the same as t0.
   PrecisionTimestamp timestamp = 6;
 
   // The offset, in seconds, relative to timestamp when the first sample occurs.
   //
   // When setting time_offset, either both t0 and timestamp should remain unset
-  // or both should be set such that t0 = timestamp + time_offset.
+  // or both should be set such that t0 = timestamp + time_offset. If time_offset
+  // is unset, it is inferred to be 0.
   double time_offset = 7;
 
   // The timestamps for each sample in y_data.
@@ -249,13 +257,15 @@ message DigitalWaveform {
   // A timestamp denoting some external stimulus like a trigger.
   //
   // When setting timestamp, you should also always set t0 and time_offset such
-  // that t0 = timestamp + time_offset.
+  // that t0 = timestamp + time_offset. If timestamp is unset, it is inferred
+  // that timestamp is the same as t0.
   PrecisionTimestamp timestamp = 6;
 
   // The offset, in seconds, relative to timestamp when the first sample occurs.
   //
   // When setting time_offset, either both t0 and timestamp should remain unset
-  // or both should be set such that t0 = timestamp + time_offset.
+  // or both should be set such that t0 = timestamp + time_offset. If time_offset
+  // is unset, it is inferred to be 0.
   double time_offset = 7;
 
   // The timestamps for each sample in y_data.

--- a/ni/protobuf/types/waveform.proto
+++ b/ni/protobuf/types/waveform.proto
@@ -34,6 +34,34 @@ message DoubleAnalogWaveform {
   map<string, WaveformAttributeValue> attributes = 4;
 }
 
+// An analog waveform with irregular timing.
+message IrregularDoubleAnalogWaveform {
+  // The timestamps for each sample in y_data. The length of this field and y_data should match.
+  repeated PrecisionTimestamp timestamps = 1;
+  
+  // The waveform values associated with timestamps. The length of this field and timestamps should match.
+  repeated double y_data = 2;
+  
+  // Attribute names and values. See WaveformAttributeValue for more details.
+  map<string, WaveformAttributeValue> attributes = 3;
+}
+
+// An analog waveform with a relative start time.
+message RelativeDoubleAnalogWaveform {
+  // Relative start time in seconds as a double rather than an absolute timestamp.
+  // This time offset is typically relative to an external event, such as a trigger.
+  double time_offset = 1;
+
+  // The time interval in seconds between data points in the waveform.
+  double dt = 2;
+
+  // The data values of the waveform.
+  repeated double y_data = 3;
+
+  // Attribute names and values. See WaveformAttributeValue for more details.
+  map<string, WaveformAttributeValue> attributes = 4;
+}
+
 // A 16-bit integer analog waveform with timing and extended properties.
 message I16AnalogWaveform {
   // The time of the first sample in y_data.
@@ -154,33 +182,6 @@ message DigitalWaveform {
 
   // Attribute names and values. See WaveformAttributeValue for more details.
   map<string, WaveformAttributeValue> attributes = 5;
-}
-
-// An analog waveform with irregular timing.
-message IrregularDoubleAnalogWaveform {
-  // The timestamps for each sample in y_data. The length of this field and y_data should match.
-  repeated PrecisionTimestamp timestamps = 1;
-  
-  // The waveform values associated with timestamps. The length of this field and timestamps should match.
-  repeated double y_data = 2;
-  
-  // Attribute names and values. See WaveformAttributeValue for more details.
-  map<string, WaveformAttributeValue> attributes = 3;
-}
-
-// An analog waveform with a relative start time.
-message RelativeDoubleAnalogWaveform {
-  // Relative start time in seconds as a double rather than an absolute timestamp.
-  double time_offset = 1;
-
-  // The time interval in seconds between data points in the waveform.
-  double dt = 2;
-
-  // The data values of the waveform.
-  repeated double y_data = 3;
-
-  // Attribute names and values. See WaveformAttributeValue for more details.
-  map<string, WaveformAttributeValue> attributes = 4;
 }
 
 // Scaling information for converting unscaled waveform data to scaled data.

--- a/ni/protobuf/types/waveform.proto
+++ b/ni/protobuf/types/waveform.proto
@@ -32,34 +32,19 @@ message DoubleAnalogWaveform {
 
   // Attribute names and values. See WaveformAttributeValue for more details.
   map<string, WaveformAttributeValue> attributes = 4;
-}
 
-// An analog waveform with irregular timing.
-message IrregularDoubleAnalogWaveform {
+  // A timestamp denoting some external stimulus like a trigger.
+  // Should be specified such that t0 = timestamp + time_offset.
+  PrecisionTimestamp timestamp = 5;
+
+  // The offset relative to timestamp when the first sample occurs.
+  // Should be specified such that t0 = timestamp + time_offset.
+  double time_offset = 6;
+
   // The timestamps for each sample in y_data. The length of this field and y_data should match.
-  repeated PrecisionTimestamp timestamps = 1;
-  
-  // The waveform values associated with timestamps. The length of this field and timestamps should match.
-  repeated double y_data = 2;
-  
-  // Attribute names and values. See WaveformAttributeValue for more details.
-  map<string, WaveformAttributeValue> attributes = 3;
-}
-
-// An analog waveform with a relative start time.
-message RelativeDoubleAnalogWaveform {
-  // Relative start time in seconds as a double rather than an absolute timestamp.
-  // This time offset is typically relative to an external event, such as a trigger.
-  double time_offset = 1;
-
-  // The time interval in seconds between data points in the waveform.
-  double dt = 2;
-
-  // The data values of the waveform.
-  repeated double y_data = 3;
-
-  // Attribute names and values. See WaveformAttributeValue for more details.
-  map<string, WaveformAttributeValue> attributes = 4;
+  // This is for use in cases where the waveform has irregular timing. This timestamps field
+  // is mutually exclusive with t0/timestamp/time_offset.
+  repeated PrecisionTimestamp timestamps = 7;
 }
 
 // A 16-bit integer analog waveform with timing and extended properties.
@@ -78,6 +63,19 @@ message I16AnalogWaveform {
 
   // Optional scaling information used to convert raw data to scaled data.
   Scale scale = 5;
+
+  // A timestamp denoting some external stimulus like a trigger.
+  // Should be specified such that t0 = timestamp + time_offset.
+  PrecisionTimestamp timestamp = 6;
+
+  // The offset relative to timestamp when the first sample occurs.
+  // Should be specified such that t0 = timestamp + time_offset.
+  double time_offset = 7;
+
+  // The timestamps for each sample in y_data. The length of this field and y_data should match.
+  // This is for use in cases where the waveform has irregular timing. This timestamps field
+  // is mutually exclusive with t0/timestamp/time_offset.
+  repeated PrecisionTimestamp timestamps = 8;
 }
 
 // A double-precision complex waveform with timing and extended properties.

--- a/ni/protobuf/types/waveform.proto
+++ b/ni/protobuf/types/waveform.proto
@@ -22,8 +22,9 @@ option ruby_package = "NI::Protobuf::Types";
 // A double-precision analog waveform with timing and extended properties.
 message DoubleAnalogWaveform {
   // The time of the first sample in y_data.
-  // If unset, consumers should infer the value based on timestamp and time_offset,
-  // unless those values are also unset.
+  //
+  // Leave t0 unset only when the start time is unknown or when the waveform
+  // has irregular timing and the timestamps field is used instead.
   PrecisionTimestamp t0 = 1;
 
   // The time interval in seconds between data points in the waveform.
@@ -36,28 +37,31 @@ message DoubleAnalogWaveform {
   map<string, WaveformAttributeValue> attributes = 4;
 
   // A timestamp denoting some external stimulus like a trigger.
-  // Should be specified such that t0 = timestamp + time_offset.
-  // If unset, consumers should infer the value based on t0 and time_offset,
-  // unless those values are also unset.
+  //
+  // When setting timestamp, you should also always set t0 and time_offset such
+  // that t0 = timestamp + time_offset.
   PrecisionTimestamp timestamp = 5;
 
   // The offset, in seconds, relative to timestamp when the first sample occurs.
-  // Should be specified such that t0 = timestamp + time_offset.
-  // If unset, consumers should infer the value based on t0 and timestamp,
-  // unless those values are also unset.
+  //
+  // When setting time_offset, either both t0 and timestamp should remain unset
+  // or both should be set such that t0 = timestamp + time_offset.
   double time_offset = 6;
 
-  // The timestamps for each sample in y_data. The length of this field and y_data should match.
-  // This is for use in cases where the waveform has irregular timing. This timestamps field
-  // is mutually exclusive with t0/timestamp/time_offset/dt.
+  // The timestamps for each sample in y_data.
+  //
+  // The length of this field and y_data should match. This is for use in cases where
+  // the waveform has irregular timing. This timestamps field is mutually exclusive
+  // with t0/timestamp/time_offset/dt.
   repeated PrecisionTimestamp timestamps = 7;
 }
 
 // A 16-bit integer analog waveform with timing and extended properties.
 message I16AnalogWaveform {
   // The time of the first sample in y_data.
-  // If unset, consumers should infer the value based on timestamp and time_offset,
-  // unless those values are also unset.
+  //
+  // Leave t0 unset only when the start time is unknown or when the waveform
+  // has irregular timing and the timestamps field is used instead.
   PrecisionTimestamp t0 = 1;
 
   // The time interval in seconds between data points in the waveform.
@@ -73,28 +77,31 @@ message I16AnalogWaveform {
   Scale scale = 5;
 
   // A timestamp denoting some external stimulus like a trigger.
-  // Should be specified such that t0 = timestamp + time_offset.
-  // If unset, consumers should infer the value based on t0 and time_offset,
-  // unless those values are also unset.
+  //
+  // When setting timestamp, you should also always set t0 and time_offset such
+  // that t0 = timestamp + time_offset.
   PrecisionTimestamp timestamp = 6;
 
   // The offset, in seconds, relative to timestamp when the first sample occurs.
-  // Should be specified such that t0 = timestamp + time_offset.
-  // If unset, consumers should infer the value based on t0 and timestamp,
-  // unless those values are also unset.
+  //
+  // When setting time_offset, either both t0 and timestamp should remain unset
+  // or both should be set such that t0 = timestamp + time_offset.
   double time_offset = 7;
 
-  // The timestamps for each sample in y_data. The length of this field and y_data should match.
-  // This is for use in cases where the waveform has irregular timing. This timestamps field
-  // is mutually exclusive with t0/timestamp/time_offset/dt.
+  // The timestamps for each sample in y_data.
+  //
+  // The length of this field and y_data should match. This is for use in cases where
+  // the waveform has irregular timing. This timestamps field is mutually exclusive
+  // with t0/timestamp/time_offset/dt.
   repeated PrecisionTimestamp timestamps = 8;
 }
 
 // A double-precision complex waveform with timing and extended properties.
 message DoubleComplexWaveform {
   // The time of the first sample in y_data.
-  // If unset, consumers should infer the value based on timestamp and time_offset,
-  // unless those values are also unset.
+  //
+  // Leave t0 unset only when the start time is unknown or when the waveform
+  // has irregular timing and the timestamps field is used instead.
   PrecisionTimestamp t0 = 1;
 
   // The time interval in seconds between data points in the waveform.
@@ -110,28 +117,31 @@ message DoubleComplexWaveform {
   map<string, WaveformAttributeValue> attributes = 4;
 
   // A timestamp denoting some external stimulus like a trigger.
-  // Should be specified such that t0 = timestamp + time_offset.
-  // If unset, consumers should infer the value based on t0 and time_offset,
-  // unless those values are also unset.
+  //
+  // When setting timestamp, you should also always set t0 and time_offset such
+  // that t0 = timestamp + time_offset.
   PrecisionTimestamp timestamp = 5;
 
   // The offset, in seconds, relative to timestamp when the first sample occurs.
-  // Should be specified such that t0 = timestamp + time_offset.
-  // If unset, consumers should infer the value based on t0 and timestamp,
-  // unless those values are also unset.
+  //
+  // When setting time_offset, either both t0 and timestamp should remain unset
+  // or both should be set such that t0 = timestamp + time_offset.
   double time_offset = 6;
 
-  // The timestamps for each sample in y_data. The length of this field and y_data should match.
-  // This is for use in cases where the waveform has irregular timing. This timestamps field
-  // is mutually exclusive with t0/timestamp/time_offset/dt.
+  // The timestamps for each sample in y_data.
+  //
+  // The length of this field and y_data should match. This is for use in cases where
+  // the waveform has irregular timing. This timestamps field is mutually exclusive
+  // with t0/timestamp/time_offset/dt.
   repeated PrecisionTimestamp timestamps = 7;
 }
 
 // A 16-bit integer complex waveform with timing and extended properties.
 message I16ComplexWaveform {
   // The time of the first sample in y_data.
-  // If unset, consumers should infer the value based on timestamp and time_offset,
-  // unless those values are also unset.
+  //
+  // Leave t0 unset only when the start time is unknown or when the waveform
+  // has irregular timing and the timestamps field is used instead.
   PrecisionTimestamp t0 = 1;
 
   // The time interval in seconds between data points in the waveform.
@@ -150,20 +160,22 @@ message I16ComplexWaveform {
   Scale scale = 5;
 
   // A timestamp denoting some external stimulus like a trigger.
-  // Should be specified such that t0 = timestamp + time_offset.
-  // If unset, consumers should infer the value based on t0 and time_offset,
-  // unless those values are also unset.
+  //
+  // When setting timestamp, you should also always set t0 and time_offset such
+  // that t0 = timestamp + time_offset.
   PrecisionTimestamp timestamp = 6;
 
   // The offset, in seconds, relative to timestamp when the first sample occurs.
-  // Should be specified such that t0 = timestamp + time_offset.
-  // If unset, consumers should infer the value based on t0 and timestamp,
-  // unless those values are also unset.
+  //
+  // When setting time_offset, either both t0 and timestamp should remain unset
+  // or both should be set such that t0 = timestamp + time_offset.
   double time_offset = 7;
 
-  // The timestamps for each sample in y_data. The length of this field and y_data should match.
-  // This is for use in cases where the waveform has irregular timing. This timestamps field
-  // is mutually exclusive with t0/timestamp/time_offset/dt.
+  // The timestamps for each sample in y_data.
+  //
+  // The length of this field and y_data should match. This is for use in cases where
+  // the waveform has irregular timing. This timestamps field is mutually exclusive
+  // with t0/timestamp/time_offset/dt.
   repeated PrecisionTimestamp timestamps = 8;
 }
 
@@ -214,8 +226,9 @@ message WaveformAttributeValue {
 // A digital waveform as bytes with timing and extended properties.
 message DigitalWaveform {
   // The time of the first sample in y_data.
-  // If unset, consumers should infer the value based on timestamp and time_offset,
-  // unless those values are also unset.
+  //
+  // Leave t0 unset only when the start time is unknown or when the waveform
+  // has irregular timing and the timestamps field is used instead.
   PrecisionTimestamp t0 = 1;
 
   // The time interval in seconds between data points in the waveform.
@@ -234,20 +247,22 @@ message DigitalWaveform {
   map<string, WaveformAttributeValue> attributes = 5;
 
   // A timestamp denoting some external stimulus like a trigger.
-  // Should be specified such that t0 = timestamp + time_offset.
-  // If unset, consumers should infer the value based on t0 and time_offset,
-  // unless those values are also unset.
+  //
+  // When setting timestamp, you should also always set t0 and time_offset such
+  // that t0 = timestamp + time_offset.
   PrecisionTimestamp timestamp = 6;
 
   // The offset, in seconds, relative to timestamp when the first sample occurs.
-  // Should be specified such that t0 = timestamp + time_offset.
-  // If unset, consumers should infer the value based on t0 and timestamp,
-  // unless those values are also unset.
+  //
+  // When setting time_offset, either both t0 and timestamp should remain unset
+  // or both should be set such that t0 = timestamp + time_offset.
   double time_offset = 7;
 
-  // The timestamps for each sample in y_data. The length of this field and y_data should match.
-  // This is for use in cases where the waveform has irregular timing. This timestamps field
-  // is mutually exclusive with t0/timestamp/time_offset/dt.
+  // The timestamps for each sample in y_data.
+  //
+  // The length of this field and y_data should match. This is for use in cases where
+  // the waveform has irregular timing. This timestamps field is mutually exclusive
+  // with t0/timestamp/time_offset/dt.
   repeated PrecisionTimestamp timestamps = 8;
 }
 

--- a/ni/protobuf/types/waveform.proto
+++ b/ni/protobuf/types/waveform.proto
@@ -22,6 +22,8 @@ option ruby_package = "NI::Protobuf::Types";
 // A double-precision analog waveform with timing and extended properties.
 message DoubleAnalogWaveform {
   // The time of the first sample in y_data.
+  // If unset, consumers should infer the value based on timestamp and time_offset,
+  // unless those values are also unset.
   PrecisionTimestamp t0 = 1;
 
   // The time interval in seconds between data points in the waveform.
@@ -35,21 +37,27 @@ message DoubleAnalogWaveform {
 
   // A timestamp denoting some external stimulus like a trigger.
   // Should be specified such that t0 = timestamp + time_offset.
+  // If unset, consumers should infer the value based on t0 and time_offset,
+  // unless those values are also unset.
   PrecisionTimestamp timestamp = 5;
 
-  // The offset relative to timestamp when the first sample occurs.
+  // The offset, in seconds, relative to timestamp when the first sample occurs.
   // Should be specified such that t0 = timestamp + time_offset.
+  // If unset, consumers should infer the value based on t0 and timestamp,
+  // unless those values are also unset.
   double time_offset = 6;
 
   // The timestamps for each sample in y_data. The length of this field and y_data should match.
   // This is for use in cases where the waveform has irregular timing. This timestamps field
-  // is mutually exclusive with t0/timestamp/time_offset.
+  // is mutually exclusive with t0/timestamp/time_offset/dt.
   repeated PrecisionTimestamp timestamps = 7;
 }
 
 // A 16-bit integer analog waveform with timing and extended properties.
 message I16AnalogWaveform {
   // The time of the first sample in y_data.
+  // If unset, consumers should infer the value based on timestamp and time_offset,
+  // unless those values are also unset.
   PrecisionTimestamp t0 = 1;
 
   // The time interval in seconds between data points in the waveform.
@@ -66,21 +74,27 @@ message I16AnalogWaveform {
 
   // A timestamp denoting some external stimulus like a trigger.
   // Should be specified such that t0 = timestamp + time_offset.
+  // If unset, consumers should infer the value based on t0 and time_offset,
+  // unless those values are also unset.
   PrecisionTimestamp timestamp = 6;
 
-  // The offset relative to timestamp when the first sample occurs.
+  // The offset, in seconds, relative to timestamp when the first sample occurs.
   // Should be specified such that t0 = timestamp + time_offset.
+  // If unset, consumers should infer the value based on t0 and timestamp,
+  // unless those values are also unset.
   double time_offset = 7;
 
   // The timestamps for each sample in y_data. The length of this field and y_data should match.
   // This is for use in cases where the waveform has irregular timing. This timestamps field
-  // is mutually exclusive with t0/timestamp/time_offset.
+  // is mutually exclusive with t0/timestamp/time_offset/dt.
   repeated PrecisionTimestamp timestamps = 8;
 }
 
 // A double-precision complex waveform with timing and extended properties.
 message DoubleComplexWaveform {
   // The time of the first sample in y_data.
+  // If unset, consumers should infer the value based on timestamp and time_offset,
+  // unless those values are also unset.
   PrecisionTimestamp t0 = 1;
 
   // The time interval in seconds between data points in the waveform.
@@ -94,11 +108,30 @@ message DoubleComplexWaveform {
 
   // Attribute names and values. See WaveformAttributeValue for more details.
   map<string, WaveformAttributeValue> attributes = 4;
+
+  // A timestamp denoting some external stimulus like a trigger.
+  // Should be specified such that t0 = timestamp + time_offset.
+  // If unset, consumers should infer the value based on t0 and time_offset,
+  // unless those values are also unset.
+  PrecisionTimestamp timestamp = 5;
+
+  // The offset, in seconds, relative to timestamp when the first sample occurs.
+  // Should be specified such that t0 = timestamp + time_offset.
+  // If unset, consumers should infer the value based on t0 and timestamp,
+  // unless those values are also unset.
+  double time_offset = 6;
+
+  // The timestamps for each sample in y_data. The length of this field and y_data should match.
+  // This is for use in cases where the waveform has irregular timing. This timestamps field
+  // is mutually exclusive with t0/timestamp/time_offset/dt.
+  repeated PrecisionTimestamp timestamps = 7;
 }
 
 // A 16-bit integer complex waveform with timing and extended properties.
 message I16ComplexWaveform {
   // The time of the first sample in y_data.
+  // If unset, consumers should infer the value based on timestamp and time_offset,
+  // unless those values are also unset.
   PrecisionTimestamp t0 = 1;
 
   // The time interval in seconds between data points in the waveform.
@@ -115,6 +148,23 @@ message I16ComplexWaveform {
 
   // Optional scaling information used to convert raw data to scaled data.
   Scale scale = 5;
+
+  // A timestamp denoting some external stimulus like a trigger.
+  // Should be specified such that t0 = timestamp + time_offset.
+  // If unset, consumers should infer the value based on t0 and time_offset,
+  // unless those values are also unset.
+  PrecisionTimestamp timestamp = 6;
+
+  // The offset, in seconds, relative to timestamp when the first sample occurs.
+  // Should be specified such that t0 = timestamp + time_offset.
+  // If unset, consumers should infer the value based on t0 and timestamp,
+  // unless those values are also unset.
+  double time_offset = 7;
+
+  // The timestamps for each sample in y_data. The length of this field and y_data should match.
+  // This is for use in cases where the waveform has irregular timing. This timestamps field
+  // is mutually exclusive with t0/timestamp/time_offset/dt.
+  repeated PrecisionTimestamp timestamps = 8;
 }
 
 // A double-precision frequency spectrum with extended properties.
@@ -164,6 +214,8 @@ message WaveformAttributeValue {
 // A digital waveform as bytes with timing and extended properties.
 message DigitalWaveform {
   // The time of the first sample in y_data.
+  // If unset, consumers should infer the value based on timestamp and time_offset,
+  // unless those values are also unset.
   PrecisionTimestamp t0 = 1;
 
   // The time interval in seconds between data points in the waveform.
@@ -180,6 +232,23 @@ message DigitalWaveform {
 
   // Attribute names and values. See WaveformAttributeValue for more details.
   map<string, WaveformAttributeValue> attributes = 5;
+
+  // A timestamp denoting some external stimulus like a trigger.
+  // Should be specified such that t0 = timestamp + time_offset.
+  // If unset, consumers should infer the value based on t0 and time_offset,
+  // unless those values are also unset.
+  PrecisionTimestamp timestamp = 6;
+
+  // The offset, in seconds, relative to timestamp when the first sample occurs.
+  // Should be specified such that t0 = timestamp + time_offset.
+  // If unset, consumers should infer the value based on t0 and timestamp,
+  // unless those values are also unset.
+  double time_offset = 7;
+
+  // The timestamps for each sample in y_data. The length of this field and y_data should match.
+  // This is for use in cases where the waveform has irregular timing. This timestamps field
+  // is mutually exclusive with t0/timestamp/time_offset/dt.
+  repeated PrecisionTimestamp timestamps = 8;
 }
 
 // Scaling information for converting unscaled waveform data to scaled data.

--- a/ni/protobuf/types/waveform.proto
+++ b/ni/protobuf/types/waveform.proto
@@ -46,8 +46,7 @@ message DoubleAnalogWaveform {
   // The offset, in seconds, relative to timestamp when the first sample occurs.
   //
   // When setting time_offset, either both t0 and timestamp should remain unset
-  // or both should be set such that t0 = timestamp + time_offset. If time_offset
-  // is unset, it is inferred to be 0.
+  // or both should be set such that t0 = timestamp + time_offset.
   double time_offset = 6;
 
   // The timestamps for each sample in y_data.
@@ -88,8 +87,7 @@ message I16AnalogWaveform {
   // The offset, in seconds, relative to timestamp when the first sample occurs.
   //
   // When setting time_offset, either both t0 and timestamp should remain unset
-  // or both should be set such that t0 = timestamp + time_offset. If time_offset
-  // is unset, it is inferred to be 0.
+  // or both should be set such that t0 = timestamp + time_offset.
   double time_offset = 7;
 
   // The timestamps for each sample in y_data.
@@ -130,8 +128,7 @@ message DoubleComplexWaveform {
   // The offset, in seconds, relative to timestamp when the first sample occurs.
   //
   // When setting time_offset, either both t0 and timestamp should remain unset
-  // or both should be set such that t0 = timestamp + time_offset. If time_offset
-  // is unset, it is inferred to be 0.
+  // or both should be set such that t0 = timestamp + time_offset.
   double time_offset = 6;
 
   // The timestamps for each sample in y_data.
@@ -175,8 +172,7 @@ message I16ComplexWaveform {
   // The offset, in seconds, relative to timestamp when the first sample occurs.
   //
   // When setting time_offset, either both t0 and timestamp should remain unset
-  // or both should be set such that t0 = timestamp + time_offset. If time_offset
-  // is unset, it is inferred to be 0.
+  // or both should be set such that t0 = timestamp + time_offset.
   double time_offset = 7;
 
   // The timestamps for each sample in y_data.
@@ -264,8 +260,7 @@ message DigitalWaveform {
   // The offset, in seconds, relative to timestamp when the first sample occurs.
   //
   // When setting time_offset, either both t0 and timestamp should remain unset
-  // or both should be set such that t0 = timestamp + time_offset. If time_offset
-  // is unset, it is inferred to be 0.
+  // or both should be set such that t0 = timestamp + time_offset.
   double time_offset = 7;
 
   // The timestamps for each sample in y_data.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

In order to support "Relative Waveforms" and "Irregular Waveforms", this PR adds new fields to waveform messages that contain timing info.
- Relative Waveforms
   - `timestamp` - The timestamp of some external event like a trigger.
   - `time_offset` - The time between `timestamp` and `t0`.
- Irregular Waveforms
   - `timestamps` - An array of timestamps. One for each value of Y Data.

We decided to add these new message fields rather than create unique new message types "RelativeWaveform" and "IrregularWaveform".

### Why should this Pull Request be merged?

Implements the proto changes for [AB#3823421](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3823421)

### What testing has been done?

None
