### PR TITLE
Add documentation for data_moniker.proto

### DIFF
--- a/ni/datamonikers/v1/data_moniker.proto
+++ b/ni/datamonikers/v1/data_moniker.proto
@@ -16,6 +16,7 @@ option csharp_namespace = "NationalInstruments.DataMonikers";
 option cc_enable_arenas = true;
 
 // Service for reading and writing data values using data monikers.
+//
 // Not all implementations implement all RPCs and clients should
 // handle this gracefully.
 service MonikerService {
@@ -23,7 +24,7 @@ service MonikerService {
   // RPC when higher throughput or lower latency are required beyond what
   // is traditionally possible with the standard gRPC transport.
   //
-  // The client supplies the preferred `strategy` and the list of monikers.
+  // The client supplies the preferred strategy and the list of monikers.
   // The server responds with the selected strategy plus the connection
   // metadata needed to establish the sideband channel. After this call,
   // the actual data exchange is expected to happen over the selected
@@ -35,6 +36,10 @@ service MonikerService {
   // order of data values returned matches the order of the read monikers.
   // The semantics for when data is published and how updates are triggered
   // is implementation dependent.
+  //
+  // Status codes for errors:
+  //
+  // - NOT_FOUND: Specified moniker does not exist
   rpc StreamRead(MonikerList) returns (stream MonikerReadResult) {};
 
   // Streams values to one or more monikers. The first request message specifies
@@ -45,6 +50,10 @@ service MonikerService {
   // positionally with the monikers declared in the first message. Implementations
   // may choose to return a response message after each request has been processed
   // for flow control purposes or no response message at all.
+  //
+  // Status codes for errors:
+  //
+  // - NOT_FOUND: Specified moniker does not exist
   rpc StreamWrite(stream MonikerWriteRequest) returns (stream StreamWriteResponse) {};
 
   // Streams data to and from the specified read and write monikers. The first
@@ -58,16 +67,26 @@ service MonikerService {
   // monikers similar to the StreamRead RPC. Write monikers are always updated before
   // data is read from the read monikers.Communication continues in this ping-pong
   // fashion until the stream is closed.
+  //
+  // Status codes for errors:
+  //
+  // - NOT_FOUND: Specified moniker does not exist
   rpc StreamReadWrite(stream MonikerWriteRequest) returns (stream MonikerReadResult) {};
 
   // Reads the current value for a single moniker. If no data value is available,
-  // Implementations may choose to return an empty response or a NOT_FOUND error.
+  // Implementations may choose to return an empty response or return an error.
+  //
+  // Status codes for errors:
+  //
+  // - NOT_FOUND: Specified moniker does not exist
   rpc ReadFromMoniker(Moniker) returns (ReadFromMonikerResult) {};
 
   // Writes a single value to a single moniker.
-  // Returns NOT_FOUND error if the moniker does not exist.
-  // Returns INVALID_ARGUMENT if the data type of the data value is not appropriate
-  // for the moniker.
+  //
+  // Status codes for errors:
+  //
+  // - NOT_FOUND: Specified moniker does not exist
+  // - INVALID_ARGUMENT: Data type of the data value is not compatible with the moniker
   rpc WriteToMoniker(WriteToMonikerRequest) returns (WriteToMonikerResponse) {};
 }
 
@@ -118,12 +137,12 @@ message Moniker {
   int64 data_instance = 3;
 }
 
-// Message which contains a batch of data values. For reads, `values`
+// Message which contains a batch of data values. For reads, values
 // contains the returned data values for one or more data monikers. For
-// writes, `values` contains the data values to be applied to one or more
+// writes, values contains the data values to be applied to one or more
 // data monikers.
 message MonikerValues {
-  // Data values carried as protobuf `Any` messages.
+  // Data values carried as protobuf Any messages.
   repeated google.protobuf.Any values = 1;
 }
 
@@ -148,13 +167,6 @@ message BeginMonikerSidebandStreamRequest {
   MonikerList monikers = 2;
 }
 
-// Response returned after sideband negotiation.
-//
-// Intended usage:
-// - `strategy` is the selected transport actually in effect.
-// - `connection_url` identifies where the client should connect.
-// - `sideband_identifier` correlates the negotiated session across endpoints.
-// - `buffer_size` communicates the recommended transfer buffer size.
 message BeginMonikerSidebandStreamResponse {
   // Selected transport used for the the sideband communication channel.
   SidebandStrategy strategy = 1;
@@ -199,7 +211,7 @@ message WriteToMonikerRequest {
   // The data moniker to update.
   Moniker moniker = 1;
 
-  // The data value to write to the `moniker`.
+  // The data value to write to the moniker.
   google.protobuf.Any value = 2;
 }
 

--- a/ni/datamonikers/v1/data_moniker.proto
+++ b/ni/datamonikers/v1/data_moniker.proto
@@ -13,88 +13,193 @@ package ni.datamonikers.v1;
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 option csharp_namespace = "NationalInstruments.DataMonikers";
+option cc_enable_arenas = true;
 
-// Service for reading and writing data using monikers
+// Service for reading and writing data values using data monikers.
+// Not all implementations implement all RPCs and clients should
+// handle this gracefully.
 service MonikerService {
+  // Negotiates a sideband transport for the specified monikers. Use this
+  // RPC when higher throughput or lower latency are required beyond what
+  // is traditionally possible with the standard gRPC transport.
+  //
+  // The client supplies the preferred `strategy` and the list of monikers.
+  // The server responds with the selected strategy plus the connection
+  // metadata needed to establish the sideband channel. After this call,
+  // the actual data exchange is expected to happen over the selected
+  // sideband transport, not over this unary RPC.
   rpc BeginSidebandStream(BeginMonikerSidebandStreamRequest) returns (BeginMonikerSidebandStreamResponse) {};
+
+  // Subscribes to updates from the requested monikers. A response message
+  // is returned once a data value is available from each read moniker. The
+  // order of data values returned matches the order of the read monikers.
+  // The semantics for when data is published and how updates are triggered
+  // is implementation dependent.
   rpc StreamRead(MonikerList) returns (stream MonikerReadResult) {};
+
+  // Streams values to one or more monikers. The first request message specifies
+  // the write monikers that will be updated. Subsequent request messages
+  // supply new data values to be written to the monikers. The number of data
+  // values in each request message must match the number of monikers supplied
+  // in the original request. The data values are applied in order and are paired
+  // positionally with the monikers declared in the first message. Implementations
+  // may choose to return a response message after each request has been processed
+  // for flow control purposes or no response message at all.
   rpc StreamWrite(stream MonikerWriteRequest) returns (stream StreamWriteResponse) {};
+
+  // Streams data to and from the specified read and write monikers. The first
+  // request message is used to setup the stream and specifies the monikers that
+  // are to be read and written. No response message is sent for the first request
+  // message.
+  //
+  // The second and subsequent request messages carry new data values to be written
+  // to the write monikers similar to the StreamWrite RPC. For each of these request
+  // message, a response message is returned containing data values from the read
+  // monikers similar to the StreamRead RPC. Write monikers are always updated before
+  // data is read from the read monikers.Communication continues in this ping-pong
+  // fashion until the stream is closed.
   rpc StreamReadWrite(stream MonikerWriteRequest) returns (stream MonikerReadResult) {};
+
+  // Reads the current value for a single moniker. If no data value is available,
+  // Implementations may choose to return an empty response or a NOT_FOUND error.
   rpc ReadFromMoniker(Moniker) returns (ReadFromMonikerResult) {};
+
+  // Writes a single value to a single moniker.
+  // Returns NOT_FOUND error if the moniker does not exist.
+  // Returns INVALID_ARGUMENT if the data type of the data value is not appropriate
+  // for the moniker.
   rpc WriteToMoniker(WriteToMonikerRequest) returns (WriteToMonikerResponse) {};
 }
 
 enum SidebandStrategy {
+  // No strategy selected.
   UNKNOWN = 0;
+
+  // Standard gRPC transport.
   GRPC = 1;
+
+  // Shared memory transport. Client and server must be on the same machine.
   SHARED_MEMORY = 2;
+
+  // Same as SHARED_MEMORY except double buffered. This uses more memory but
+  // allows the client and server to read and write at the same time without
+  // blocking each other.
   DOUBLE_BUFFERED_SHARED_MEMORY = 3;
+
+  // TCP Socket-based transport.
   SOCKETS = 4;
+
+  // TCP Socket-based transport optimized for lower latency at the expense
+  // of higher CPU usage.
   SOCKETS_LOW_LATENCY = 5;
+
+  // Hypervisor-assisted socket transport. Not currently implemented.
   HYPERVISOR_SOCKETS = 6;
+
+  // RDMA-based transport. Requires that the network card on both the client
+  // and the server support RDMA.
   RDMA = 7;
+
+  // RDMA transport optimized for lower latency at the expense of higher
+  // CPU usage.
   RDMA_LOW_LATENCY = 8;
 }
 
-// Moniker is a unique identifier for a data source.
+// Identifier used to represent a data source from which data values can
+// be read or written.
 message Moniker {
+  // Service location or endpoint identifier.
   string service_location = 1;
+
+  // Logical data source name.
   string data_source = 2;
+
+  // Specific instance identifier within the data source.
   int64 data_instance = 3;
 }
 
+// Message which contains a batch of data values. For reads, `values`
+// contains the returned data values for one or more data monikers. For
+// writes, `values` contains the data values to be applied to one or more
+// data monikers.
 message MonikerValues {
+  // Data values carried as protobuf `Any` messages.
   repeated google.protobuf.Any values = 1;
 }
 
+// Message which identifies the set of read and write monikers for a
+// particular operation.
 message MonikerList {
-  bool is_initial_write = 1;
+  // Deprecated. Preserved for backward compatibility.
+  bool is_initial_write = 1 [deprecated = true];
+
+  // Monikers from which to read.
   repeated Moniker read_monikers = 2;
+
+  // Monikers to update with new data values.
   repeated Moniker write_monikers = 3;
 }
 
 message BeginMonikerSidebandStreamRequest {
+  // The transport to use for the sideband communication channel.
   SidebandStrategy strategy = 1;
+
+  // Monikers participating in the sideband communication channel.
   MonikerList monikers = 2;
 }
 
-message BeginMonikerSidebandStreamResponse {  
+// Response returned after sideband negotiation.
+//
+// Intended usage:
+// - `strategy` is the selected transport actually in effect.
+// - `connection_url` identifies where the client should connect.
+// - `sideband_identifier` correlates the negotiated session across endpoints.
+// - `buffer_size` communicates the recommended transfer buffer size.
+message BeginMonikerSidebandStreamResponse {
+  // Selected transport used for the the sideband communication channel.
   SidebandStrategy strategy = 1;
+
+  // Transport-specific URL or endpoint used to establish the sideband connection.
   string connection_url = 2;
+
+  // Identifier used to identify communication session within the transport.
   string sideband_identifier = 3;
+
+  // The buffer size in bytes used for the sideband transport.
   sint64 buffer_size = 4;
 }
 
+// Request message used to perform streaming writes.
 message MonikerWriteRequest {
   oneof write_data {
+    // Initial handshake message that declares the target monikers.
     MonikerList monikers = 1;
+
+    // Value payload for the established write session. This field should be set
+	// on all subsequent messages after the initial handshake message.
     MonikerValues data = 2;
   }
 }
 
+// Response message used to perform streaming reads.
 message MonikerReadResult {
+  // Data values returned from the read monikers.
   MonikerValues data = 1;
-}
-
-message SidebandWriteRequest {
-  bool cancel = 1;
-  MonikerValues values = 2;
-}
-
-message SidebandReadResponse {
-  bool cancel = 1;
-  MonikerValues values = 2;
 }
 
 message StreamWriteResponse {
 }
 
 message ReadFromMonikerResult {
+  // Data value read from the moniker or empty if no value was available.
   google.protobuf.Any value = 1;
 }
 
 message WriteToMonikerRequest {
+  // The data moniker to update.
   Moniker moniker = 1;
+
+  // The data value to write to the `moniker`.
   google.protobuf.Any value = 2;
 }
 

--- a/ni/datamonikers/v2/data_moniker_service.proto
+++ b/ni/datamonikers/v2/data_moniker_service.proto
@@ -1,0 +1,186 @@
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+syntax = "proto3";
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+import "google/protobuf/any.proto";
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+package ni.datamonikers.v2;
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+option csharp_namespace = "NationalInstruments.DataMonikers.V2";
+option cc_enable_arenas = true;
+option go_package = "datamonikersv2";
+option java_multiple_files = true;
+option java_outer_classname = "DataMonikerServiceProto";
+option java_package = "com.ni.datamonikers.v2";
+option objc_class_prefix = "NIDM";
+option php_namespace = "NI\\DataMonikers\\V2";
+option ruby_package = "NI::DataMonikers::V2";
+
+// Service for reading and writing data values using data monikers.
+// Not all implementations implement all RPCs and clients should
+// handle this gracefully.
+service DataMonikerService {
+  // Reads the current value for a single moniker. If no data value is available,
+  // Implementations may choose to return an empty response.
+  // Returns NOT_FOUND error if the moniker does not exist.
+  rpc ReadValueFromMoniker(ReadValueFromMonikerRequest) returns (ReadValueFromMonikerResponse) {};
+
+  // Writes a single value to a single moniker.
+  // Returns NOT_FOUND error if the moniker does not exist.
+  // Returns INVALID_ARGUMENT if the data type of the data value is not appropriate
+  // for the moniker.
+  rpc WriteValueToMoniker(WriteValueToMonikerRequest) returns (WriteValueToMonikerResponse) {};
+
+  // Reads multiple values from one or more monikers. A response message is
+  // returned once a data value is available from each moniker. The order of
+  // data values returned matches the moniker order specified in the request
+  // message. The semantics for when data is published and how updates are
+  // triggered is implementation dependent.
+  rpc ReadValuesFromMonikersStream(ReadValuesFromMonikersStreamRequest) returns (stream ReadValuesFromMonikersStreamResponse) {};
+
+  // Writes multiple values to one or more monikers. The first request message
+  // specifies the monikers that will be updated. Subsequent request messages
+  // supply new data values to be written to the monikers. The number of data
+  // values in each write request must match the number of monikers supplied
+  // in the initialize request, and the data values are paired positionally with
+  // the monikers specified in the initialize message.
+  rpc WriteValuesToMonikersStream(stream WriteValuesToMonikersStreamRequest) returns (WriteValuesToMonikersStreamResponse) {};
+
+  // Reads and writes multiple values from one or more monikers. The first request
+  // message is used to initialize the stream and specifies the monikers to read
+  // and write. No response message is sent for this initialize request message.
+  //
+  // The second and subsequent request messages carry new data values to be written
+  // to the write monikers. For each of these data request messages, a response
+  // message is returned containing data values from the read monikers. Write
+  // monikers are always updated before data is read from the read monikers.
+  // Communication continues in this ping-pong fashion until the stream is closed.
+  rpc ReadWriteValuesForMonikersStream(stream ReadWriteValuesForMonikersStreamRequest) returns (stream ReadWriteValuesForMonikersStreamResult) {};
+
+  // This would be BatchReadValueFromMoniker following google AIPs
+  rpc ReadValueFromMonikers(ReadValueFromMonikersRequest) returns (ReadValueFromMonikersResponse) {};
+  rpc ReadValuesFromMonikerStream(ReadValuesFromMonikerStreamRequest) returns (stream ReadValuesFromMonikerStreamResponse) {};
+  rpc ReadChunkedValueFromMonikerStream(ReadChunkedValueFromMonikerStreamRequest) returns (stream ReadChunkedValueFromMonikerStreamResponse) {};
+
+  // This would be BatchWriteValueToMoniker following google AIPs
+  rpc WriteValueToMonikers(WriteValueToMonikersRequest) returns (WriteValueToMonikersResponse) {};
+  rpc WriteValuesToMonikerStream(WriteValuesToMonikerStreamRequest) returns (stream WriteValuesToMonikerStreamResponse) {};
+  rpc WriteChunkedValueToMonikerStream(stream WriteChunkedValueToMonikerStreamRequest) returns (WriteChunkedValueToMonikerStreamResponse) {};
+}
+
+// Identifier used to represent a data source from which data values can
+// be read or written.
+message Moniker {
+  // Service location or endpoint identifier.
+  string service_location = 1;
+
+  // Logical data source name.
+  string data_source = 2;
+
+  // Specific instance identifier within the data source.
+  int64 data_instance = 3;
+}
+
+message MonikerDataValue {
+  // The moniker the data value belongs to.
+  Moniker moniker = 1;
+
+  // The data value for the `moniker`.
+  google.protobuf.Any value = 2;
+}
+
+message ReadValueFromMonikerRequest {
+  // The data moniker from which to read.
+  Moniker moniker = 1;
+}
+
+message ReadValueFromMonikerResponse {
+  // Data value read from the moniker or empty if no value was available.
+  google.protobuf.Any value = 2;
+}
+
+message WriteValueToMonikerRequest {
+  // The data value to write to the moniker.
+  MonikerDataValue value = 1;
+}
+
+message WriteValueToMonikerResponse {
+}
+
+message ReadValuesFromMonikersStreamRequest {
+  // The data monikers to subscribe to for updates.
+  repeated Moniker monikers = 1;
+}
+
+message ReadValuesFromMonikersStreamResponse {
+  // Data values read from the monikers.
+  repeated google.protobuf.Any values = 1;
+}
+
+message WriteValuesToMonikersStreamRequest {
+
+  // Request message sent first to initialize the stream.
+  message InitializeStreamRequest {
+	// The list of monikers that will be written with each `WriteDataRequest`
+    repeated Moniker monikers = 1;
+  }
+
+  // Request message used to write new data values to the monikers.
+  message WriteDataRequest {
+	// The data values to write to `monikers`. The number of data values must
+	// match the number of monikers specified in the `InitializeStreamRequest`
+	// and the data values are paired positionally with the `monikers`.
+	repeated google.protobuf.Any values = 1;
+  }
+
+  oneof request {
+    // Initial handshake message that declares the target monikers.
+    InitializeStreamRequest initialize = 1;
+
+    // Value payload for the established stream. This field should be set
+	// on all subsequent requests after the initialize request.
+    WriteDataRequest write_data = 2;
+  }
+}
+
+message WriteValuesToMonikersStreamResponse {
+}
+
+message ReadWriteValuesForMonikersStreamRequest {
+  // Request message sent first to initialize the stream.
+  message InitializeStreamRequest {
+	// The list of monikers that will be read with each `WriteDataRequest`
+    repeated Moniker read_monikers = 2;
+
+    // The list of monikers that will be written with each `WriteDataRequest`
+    repeated Moniker write_monikers = 3;
+  }
+
+  // Request message used to write new data values to the monikers.
+  message ReadWriteDataRequest {
+	// The data values to write to `write_monikers`. The number of data values must
+	// match the number of `write_monikers` specified in the `InitializeStreamRequest`
+	// and the data values are paired positionally with the `write_monikers`.
+	repeated google.protobuf.Any values = 1;
+  }
+
+  oneof request {
+    // Initial handshake message that declares the target monikers.
+    InitializeStreamRequest initialize = 1;
+
+    // Value payload for the established stream. This field should be set
+	// on all subsequent requests after the initialize request.
+    ReadWriteDataRequest read_write_data = 2;
+  }
+}
+
+message ReadWriteValuesForMonikersStreamResponse {
+  // Data values read from the monikers.
+  repeated google.protobuf.Any values = 1;
+}

--- a/ni/datamonikers/v2/data_moniker_service.proto
+++ b/ni/datamonikers/v2/data_moniker_service.proto
@@ -23,18 +23,24 @@ option php_namespace = "NI\\DataMonikers\\V2";
 option ruby_package = "NI::DataMonikers::V2";
 
 // Service for reading and writing data values using data monikers.
+//
 // Not all implementations implement all RPCs and clients should
 // handle this gracefully.
 service DataMonikerService {
   // Reads the current value for a single moniker. If no data value is available,
   // Implementations may choose to return an empty response.
-  // Returns NOT_FOUND error if the moniker does not exist.
+  //
+  // Status codes for errors:
+  //
+  // - NOT_FOUND: Specified moniker does not exist
   rpc ReadValueFromMoniker(ReadValueFromMonikerRequest) returns (ReadValueFromMonikerResponse) {};
 
   // Writes a single value to a single moniker.
-  // Returns NOT_FOUND error if the moniker does not exist.
-  // Returns INVALID_ARGUMENT if the data type of the data value is not appropriate
-  // for the moniker.
+  //
+  // Status codes for errors:
+  //
+  // - NOT_FOUND: Specified moniker does not exist
+  // - INVALID_ARGUMENT: Data type of the data value is not compatible with the moniker
   rpc WriteValueToMoniker(WriteValueToMonikerRequest) returns (WriteValueToMonikerResponse) {};
 
   // Reads multiple values from one or more monikers. A response message is
@@ -42,6 +48,8 @@ service DataMonikerService {
   // data values returned matches the moniker order specified in the request
   // message. The semantics for when data is published and how updates are
   // triggered is implementation dependent.
+  //
+  // - NOT_FOUND: Specified moniker does not exist
   rpc ReadValuesFromMonikersStream(ReadValuesFromMonikersStreamRequest) returns (stream ReadValuesFromMonikersStreamResponse) {};
 
   // Writes multiple values to one or more monikers. The first request message
@@ -50,6 +58,9 @@ service DataMonikerService {
   // values in each write request must match the number of monikers supplied
   // in the initialize request, and the data values are paired positionally with
   // the monikers specified in the initialize message.
+  //
+  // - NOT_FOUND: Specified moniker does not exist
+  // - INVALID_ARGUMENT: Data type of the data value is not compatible with the moniker
   rpc WriteValuesToMonikersStream(stream WriteValuesToMonikersStreamRequest) returns (WriteValuesToMonikersStreamResponse) {};
 
   // Reads and writes multiple values from one or more monikers. The first request
@@ -61,6 +72,9 @@ service DataMonikerService {
   // message is returned containing data values from the read monikers. Write
   // monikers are always updated before data is read from the read monikers.
   // Communication continues in this ping-pong fashion until the stream is closed.
+  //
+  // - NOT_FOUND: Specified moniker does not exist
+  // - INVALID_ARGUMENT: Data type of the data value is not compatible with the moniker
   rpc ReadWriteValuesForMonikersStream(stream ReadWriteValuesForMonikersStreamRequest) returns (stream ReadWriteValuesForMonikersStreamResult) {};
 
   // This would be BatchReadValueFromMoniker following google AIPs
@@ -101,7 +115,7 @@ message WriteValueToMonikerRequest {
   // The moniker to update.
   Moniker moniker = 1;
 
-  // The data value to write to the `moniker`.
+  // The data value to write to the moniker.
   google.protobuf.Any value = 2;
 }
 
@@ -122,15 +136,15 @@ message WriteValuesToMonikersStreamRequest {
 
   // Request message sent first to initialize the stream.
   message InitializeStreamRequest {
-	// The list of monikers that will be written with each `WriteDataRequest`
+	// The list of monikers that will be written with each WriteDataRequest
     repeated Moniker monikers = 1;
   }
 
   // Request message used to write new data values to the monikers.
   message WriteDataRequest {
-	// The data values to write to `monikers`. The number of data values must
-	// match the number of monikers specified in the `InitializeStreamRequest`
-	// and the data values are paired positionally with the `monikers`.
+	// The data values to write to monikers. The number of data values must
+	// match the number of monikers specified in the InitializeStreamRequest
+	// and the data values are paired positionally with the monikers.
 	repeated google.protobuf.Any values = 1;
   }
 
@@ -150,18 +164,18 @@ message WriteValuesToMonikersStreamResponse {
 message ReadWriteValuesForMonikersStreamRequest {
   // Request message sent first to initialize the stream.
   message InitializeStreamRequest {
-	// The list of monikers that will be read with each `WriteDataRequest`
+	// The list of monikers that will be read with each WriteDataRequest
     repeated Moniker read_monikers = 2;
 
-    // The list of monikers that will be written with each `WriteDataRequest`
+    // The list of monikers that will be written with each WriteDataRequest
     repeated Moniker write_monikers = 3;
   }
 
   // Request message used to write new data values to the monikers.
   message ReadWriteDataRequest {
-	// The data values to write to `write_monikers`. The number of data values must
-	// match the number of `write_monikers` specified in the `InitializeStreamRequest`
-	// and the data values are paired positionally with the `write_monikers`.
+	// The data values to write to write_monikers. The number of data values must
+	// match the number of write_monikers specified in the InitializeStreamRequest
+	// and the data values are paired positionally with the write_monikers.
 	repeated google.protobuf.Any values = 1;
   }
 

--- a/ni/datamonikers/v2/data_moniker_service.proto
+++ b/ni/datamonikers/v2/data_moniker_service.proto
@@ -87,14 +87,6 @@ message Moniker {
   int64 data_instance = 3;
 }
 
-message MonikerDataValue {
-  // The moniker the data value belongs to.
-  Moniker moniker = 1;
-
-  // The data value for the `moniker`.
-  google.protobuf.Any value = 2;
-}
-
 message ReadValueFromMonikerRequest {
   // The data moniker from which to read.
   Moniker moniker = 1;
@@ -106,8 +98,11 @@ message ReadValueFromMonikerResponse {
 }
 
 message WriteValueToMonikerRequest {
-  // The data value to write to the moniker.
-  MonikerDataValue value = 1;
+  // The moniker to update.
+  Moniker moniker = 1;
+
+  // The data value to write to the `moniker`.
+  google.protobuf.Any value = 2;
 }
 
 message WriteValueToMonikerResponse {


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates `data_moniker.proto`:
- Adds documentation for RPCs, messages, and fields.
- Mark unused field as deprecated.
- Adds `cc_enable_arenas` option for C++.

Adds a draft of a V2 version of the API that adheres to our protobuf guidelines and conventions and cleans the API up further.

### Why should this Pull Request be merged?

I am posting this draft PR for further discussion. There are currently 5 forked copies of this proto file across various public repos:
- this repo
- [grpc-device](https://github.com/ni/grpc-device/blob/main/imports/protobuf/data_moniker.proto)
- [nidaqmx-python](https://github.com/ni/nidaqmx-python/blob/master/src/codegen/protos/data_moniker.proto)
- [grpc-sideband](https://github.com/ni/grpc-sideband/blob/main/moniker_src/data_moniker.proto)
- [grpc-perf](https://github.com/ni/grpc-perf/blob/main/data_moniker.proto)

`grpc-device` and `nidaqmx-python` contain the exact same source but there are four unique variations in total, and none of them are API compatible with each other. The shape of the API is mostly the same but they have different package names, service names, and message names in some cases. We would like to gradually converge on a unified API that is sourced from this repo and consumed by the other repos. In that spirit, we would like to make small changes where appropriate to the current API that nudge things in that direction that don't break backward compatibility in a fashion that we are not comfortable with. I have also created a draft of a V2 API which can serve as a consolidated API for all repos and clean things up from the current API which do not conform to our conventions.

In terms of service implementations, it appears there are currently three: `grpc-device`, `grpc-sideband`, and `datastore-service`. However, the implementation from `grpc-sideband` doesn't really appear to be used and might be dead code that is more of a reference implementation than anything?

### What testing has been done?

N/A
