### PR TITLE
Back port data moniker V0 API

### DIFF
--- a/ni/datamonikers/v0/README.md
+++ b/ni/datamonikers/v0/README.md
@@ -1,0 +1,15 @@
+# Data Moniker V0 APIs
+
+This API predates the NI gRPC Protocol Buffer Style Guide and creation of this 
+repository, so it does not follow our current conventions and style for `.proto` 
+files. For example, the package name does not contain a version number and a
+number of the request and response message names do not follow current conventions.
+
+Because this API does not follow standard package naming and versioning guidelines,
+when you run `protoc` on this API or other APIs that depend on it, you may need to
+add `ni/datamonikers/v0` to the include path in order to satisfy import directives
+such as `import "data_moniker.proto"`.
+
+This file originated from:
+- Git repo: https://github.com/ni/grpc-device/blob/main/imports/protobuf/data_moniker.proto
+- Commit hash: e6081e83d9a075a4b74fd5722ff458fcf42c1e55

--- a/ni/datamonikers/v0/data_moniker.proto
+++ b/ni/datamonikers/v0/data_moniker.proto
@@ -1,0 +1,79 @@
+syntax = "proto3";
+
+option cc_enable_arenas = true;
+option csharp_namespace = "NationalInstruments.DataMonikers";
+
+package ni.data_monikers;
+
+import "google/protobuf/any.proto";
+
+service DataMoniker {
+  rpc BeginSidebandStream(BeginMonikerSidebandStreamRequest) returns (BeginMonikerSidebandStreamResponse) {};
+  rpc StreamReadWrite(stream MonikerWriteRequest) returns (stream MonikerReadResponse) {};
+  rpc StreamRead(MonikerList) returns (stream MonikerReadResponse) {};
+  rpc StreamWrite(stream MonikerWriteRequest) returns (stream StreamWriteResponse) {};
+}
+
+enum SidebandStrategy
+{
+  UNKNOWN = 0;
+  GRPC = 1;
+  SHARED_MEMORY = 2;
+  DOUBLE_BUFFERED_SHARED_MEMORY = 3;
+  SOCKETS = 4;
+  SOCKETS_LOW_LATENCY = 5;
+  HYPERVISOR_SOCKETS = 6;
+  RDMA = 7;
+  RDMA_LOW_LATENCY = 8;
+}
+
+message BeginMonikerSidebandStreamRequest {
+  SidebandStrategy strategy = 1;
+  MonikerList monikers = 2;
+}
+
+message BeginMonikerSidebandStreamResponse {
+  SidebandStrategy strategy = 1;
+  string connection_url = 2;
+  string sideband_identifier = 3;
+  sint64 buffer_size = 4;
+}
+
+message Moniker {
+  string service_location = 1;
+  string data_source = 2;
+  int64 data_instance = 3;
+}
+
+message MonikerWriteRequest {
+  oneof write_data {
+    MonikerList monikers = 1;
+    MonikerValues data = 2;
+  }
+}
+
+message MonikerReadResponse {
+  MonikerValues data = 1;
+}
+
+message MonikerList {
+  repeated Moniker read_monikers = 2;
+  repeated Moniker write_monikers = 3;
+}
+
+message MonikerValues {
+  repeated google.protobuf.Any values = 1;
+}
+
+message SidebandWriteRequest {
+  bool cancel = 1;
+  MonikerValues values = 2;
+}
+
+message SidebandReadResponse {
+  bool cancel = 1;
+  MonikerValues values = 2;
+}
+
+message StreamWriteResponse {
+}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Back ports the addition of the data moniker API that was originally produced from the grpc-device repo as the V0 version of the API.

### Why should this Pull Request be merged?

This will be the single source of truth for this version of the API so we can stop forking copies of it across various grpc repos that eventually drift from each other. Existing repos will eventually be updated to reference this copy rather than their own copy.

### What testing has been done?

N/A
