### PR TITLE
Remove pkg_resources (deprecated) and use importlib.resources instead

### DIFF
--- a/.github/check_protos/_check_protos.py
+++ b/.github/check_protos/_check_protos.py
@@ -3,8 +3,8 @@
 
 import pathlib
 import sys
+import importlib.resources
 import grpc_tools.protoc
-import pkg_resources
 
 PROTO_ROOT_PATH = pathlib.Path(__file__).parent.parent.parent
 PROTO_PATH = PROTO_ROOT_PATH / "ni"
@@ -19,7 +19,7 @@ def main():
         "protoc",
         f"--proto_path={str(PROTO_ROOT_PATH)}",
         f"--proto_path={str(GRPC_DEVICE_PROTO_PATH)}",
-        f"--proto_path={pkg_resources.resource_filename('grpc_tools', '_proto')}",
+        f"--proto_path={importlib.resources.files('grpc_tools').joinpath('_proto')}",
         f"--python_out={str(PROTO_ROOT_PATH)}",
         f"--grpc_python_out={str(PROTO_ROOT_PATH)}",
     ]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-apis/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

`pkg_resources` is being deprecated. When the check_protos code updates to setuptools 82.0.1 it will be gone and this will break.

### Why should this Pull Request be merged?

Replacing the existing code with non-deprecated code. Similar thing is being done in ni-internal-apis repo. See https://github.com/ni/ni-internal-apis/pull/201

### What testing has been done?

PR Build
